### PR TITLE
Nav Component skeleton & additional map tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Scratch-N-Map
 (Lambda Labs 7.1)
 
+Wireframes: https://balsamiq.cloud/snv27r3/pdmo5as/rFFE9 
+
 ## Code style
 - Single quotes
 - 2 spaces indentation

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,9 +8,9 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <LandingPage />
+        {/* <LandingPage /> */}
         <Dashboard />
-        <Settings />
+        {/* <Settings /> */}
       </div>
     );
   }

--- a/client/src/Components/Dashboard/Dashboard.js
+++ b/client/src/Components/Dashboard/Dashboard.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import Map from '../Map/Map';
+import Nav from '../Nav/Nav';
 import './Dashboard.css';
 
 class Dashboard extends Component {
   render() {
     return (
       <div className="Dashboard">
-        Welcome!
+        <Nav />
         <Map />
       </div>
     );

--- a/client/src/Components/Map/Map.css
+++ b/client/src/Components/Map/Map.css
@@ -1,4 +1,5 @@
 .MapComponent {
   height: 100vh;
   width: 100%;
+  z-index: 1;
 }

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -11,11 +11,20 @@ const markerIcon = L.icon({
   popupAnchor: [10, -10]
 });
 
+const mapTilesUrls = {
+  standard: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  light:
+    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', // light cartodb tile
+  dark:
+    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png' // dark cartodb tile
+};
+
 class MapComponent extends Component {
   state = {
     lat: 45.512794,
     lng: -122.679565,
-    zoom: 5
+    zoom: 5,
+    mapTile: mapTilesUrls.dark
   };
 
   render() {
@@ -24,7 +33,7 @@ class MapComponent extends Component {
       <Map center={position} zoom={this.state.zoom} className="MapComponent">
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          url={this.state.mapTile}
         />
         <Marker position={position} icon={markerIcon}>
           <Popup>

--- a/client/src/Components/Map/Map.less
+++ b/client/src/Components/Map/Map.less
@@ -1,4 +1,5 @@
 .MapComponent {
   height: 100vh;
   width: 100%;
+  z-index: 1;
 }

--- a/client/src/Components/Nav/Nav.css
+++ b/client/src/Components/Nav/Nav.css
@@ -41,8 +41,25 @@
 .Nav .MenuItem:hover {
   color: orangered;
 }
+.Nav .Center__friends {
+  font-size: 30px;
+}
+.Nav .Center__friends:hover {
+  outline: 2px solid red;
+}
+.Nav .Center__friends:focus {
+  outline: 2px solid green;
+}
 .Nav .Center__search {
   cursor: text;
+  font-size: 30px;
+  width: 150px;
+}
+.Nav .Center__search:hover {
+  outline: 2px solid red;
+}
+.Nav .Center__search:focus {
+  outline: 2px solid green;
 }
 .Nav .Right__signout {
   color: orangered;

--- a/client/src/Components/Nav/Nav.css
+++ b/client/src/Components/Nav/Nav.css
@@ -3,11 +3,11 @@
   flex-flow: row nowrap;
   justify-content: space-between;
   align-items: center;
-  border: 1px dashed red;
-  margin: 0 0 0 30px;
+  margin: 0 0 0 40px;
+  padding-left: 10px;
   width: 90%;
   height: 50px;
-  background-color: rgba(0, 0, 0, 0);
+  background-color: rgba(100, 100, 100, 0.4);
   position: absolute;
   top: 10px;
   left: 10px;
@@ -16,18 +16,26 @@
 }
 .Nav .Nav__title {
   font-size: 25px;
-  border: 1px dashed blue;
   min-width: 175px;
+  cursor: default;
 }
 .Nav .Nav__MenuItems {
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-around;
   align-items: center;
-  border: 1px dashed green;
   width: 500px;
   height: 100%;
 }
-.Nav .MenuLink {
-  border: 1px dashed green;
+.Nav .MenuItem {
+  cursor: pointer;
+}
+.Nav .MenuItem:hover {
+  color: orangered;
+}
+.Nav .MenuItems__signout {
+  color: orangered;
+}
+.Nav .MenuItems__signout:hover {
+  color: orange;
 }

--- a/client/src/Components/Nav/Nav.css
+++ b/client/src/Components/Nav/Nav.css
@@ -19,12 +19,20 @@
   min-width: 175px;
   cursor: default;
 }
-.Nav .Nav__MenuItems {
+.Nav .Nav__Center {
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-around;
   align-items: center;
-  width: 500px;
+  width: 300px;
+  height: 100%;
+}
+.Nav .Nav__Right {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-around;
+  align-items: center;
+  width: 200px;
   height: 100%;
 }
 .Nav .MenuItem {
@@ -33,9 +41,12 @@
 .Nav .MenuItem:hover {
   color: orangered;
 }
-.Nav .MenuItems__signout {
+.Nav .Center__search {
+  cursor: text;
+}
+.Nav .Right__signout {
   color: orangered;
 }
-.Nav .MenuItems__signout:hover {
+.Nav .Right__signout:hover {
   color: orange;
 }

--- a/client/src/Components/Nav/Nav.css
+++ b/client/src/Components/Nav/Nav.css
@@ -1,0 +1,33 @@
+.Nav {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px dashed red;
+  margin: 0 0 0 30px;
+  width: 90%;
+  height: 50px;
+  background-color: rgba(0, 0, 0, 0);
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
+  color: white;
+}
+.Nav .Nav__title {
+  font-size: 25px;
+  border: 1px dashed blue;
+  min-width: 175px;
+}
+.Nav .Nav__MenuItems {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-around;
+  align-items: center;
+  border: 1px dashed green;
+  width: 500px;
+  height: 100%;
+}
+.Nav .MenuLink {
+  border: 1px dashed green;
+}

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -5,11 +5,18 @@ const Nav = () => {
   return (
     <div className="Nav">
       <div className="Nav__title">Scratch-N-Map</div>
-      <div className="Nav__MenuItems">
-        <div className="MenuItem MenuItems__friends">Friends</div>
-        <div className="MenuItem MenuItems__search">Search</div>
-        <div className="MenuItem MenuItems__settings">Settings</div>
-        <div className="MenuItem MenuItems__signout">Sign Out</div>
+
+      <div className="Nav__Center">
+        <div className="MenuItem Center__friends">Friends</div>
+        <input
+          className="MenuItem Center__search"
+          type="search"
+          placeholder="search"
+        />
+      </div>
+      <div className="Nav__Right">
+        <div className="MenuItem Right__settings">Settings</div>
+        <div className="MenuItem Right__signout">Sign Out</div>
       </div>
     </div>
   );

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -1,13 +1,32 @@
 import React from 'react';
 import './Nav.css';
 
+const friendsDummyData = [
+  'My Travels',
+  'Friend 1',
+  'Friend 2',
+  'Friend 3',
+  'Friend 4'
+];
+
 const Nav = () => {
   return (
     <div className="Nav">
       <div className="Nav__title">Scratch-N-Map</div>
 
       <div className="Nav__Center">
-        <div className="MenuItem Center__friends">Friends</div>
+        {/* <div className="MenuItem Center__friends">Friends</div> */}
+        <select name="My Travels" id="" className="MenuItem Center__friends">
+          {friendsDummyData.map((friend, i) => {
+            return i === 0 ? (
+              <option value="My Travels">My Travels</option>
+            ) : (
+              <option value={friend} key={i}>
+                {friend}
+              </option>
+            );
+          })}
+        </select>
         <input
           className="MenuItem Center__search"
           type="search"

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import './Nav.css';
+
+const Nav = () => {
+  return (
+    <div className="Nav">
+      <div className="Nav__title">Scratch-N-Map</div>
+      <div className="Nav__MenuItems">
+        <div className="MenuLink MenuItems__friends">Friends</div>
+        <div className="MenuLink MenuItems__search">Search</div>
+        <div className="MenuLink MenuItems__settings">Settings</div>
+        <div className="MenuLink MenuItems__signout">Sign Out</div>
+      </div>
+    </div>
+  );
+};
+
+export default Nav;

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -6,10 +6,10 @@ const Nav = () => {
     <div className="Nav">
       <div className="Nav__title">Scratch-N-Map</div>
       <div className="Nav__MenuItems">
-        <div className="MenuLink MenuItems__friends">Friends</div>
-        <div className="MenuLink MenuItems__search">Search</div>
-        <div className="MenuLink MenuItems__settings">Settings</div>
-        <div className="MenuLink MenuItems__signout">Sign Out</div>
+        <div className="MenuItem MenuItems__friends">Friends</div>
+        <div className="MenuItem MenuItems__search">Search</div>
+        <div className="MenuItem MenuItems__settings">Settings</div>
+        <div className="MenuItem MenuItems__signout">Sign Out</div>
       </div>
     </div>
   );

--- a/client/src/Components/Nav/Nav.less
+++ b/client/src/Components/Nav/Nav.less
@@ -1,0 +1,36 @@
+.Nav {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px dashed red;
+  margin: 0 0 0 30px;
+  width: 90%;
+  height: 50px;
+  background-color: rgba(0, 0, 0, 0);
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
+  color: white;
+
+  .Nav__title {
+    font-size: 25px;
+    border: 1px dashed blue;
+    min-width: 175px;
+  }
+
+  .Nav__MenuItems {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-around;
+    align-items: center;
+    border: 1px dashed green;
+    width: 500px;
+    height: 100%;
+  }
+
+  .MenuLink {
+    border: 1px dashed green;
+  }
+}

--- a/client/src/Components/Nav/Nav.less
+++ b/client/src/Components/Nav/Nav.less
@@ -20,12 +20,21 @@
     cursor: default;
   }
 
-  .Nav__MenuItems {
+  .Nav__Center {
     display: flex;
     flex-flow: row nowrap;
     justify-content: space-around;
     align-items: center;
-    width: 500px;
+    width: 300px;
+    height: 100%;
+  }
+
+  .Nav__Right {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-around;
+    align-items: center;
+    width: 200px;
     height: 100%;
   }
 
@@ -37,7 +46,11 @@
     }
   }
 
-  .MenuItems__signout {
+  .Center__search {
+    cursor: text;
+  }
+
+  .Right__signout {
     color: orangered;
      &:hover {
        color: orange;

--- a/client/src/Components/Nav/Nav.less
+++ b/client/src/Components/Nav/Nav.less
@@ -46,8 +46,26 @@
     }
   }
 
+  .Center__friends {
+    font-size: 30px;
+    &:hover {
+      outline: 2px solid red;
+    }
+    &:focus {
+      outline: 2px solid green;
+    }
+  }
+
   .Center__search {
     cursor: text;
+    font-size: 30px;
+    width: 150px;
+    &:hover {
+      outline: 2px solid red;
+    }
+    &:focus {
+      outline: 2px solid green;
+    }
   }
 
   .Right__signout {

--- a/client/src/Components/Nav/Nav.less
+++ b/client/src/Components/Nav/Nav.less
@@ -3,11 +3,11 @@
   flex-flow: row nowrap;
   justify-content: space-between;
   align-items: center;
-  border: 1px dashed red;
-  margin: 0 0 0 30px;
+  margin: 0 0 0 40px;
+  padding-left: 10px;
   width: 90%;
   height: 50px;
-  background-color: rgba(0, 0, 0, 0);
+  background-color: rgba(100, 100, 100, 0.4);
   position: absolute;
   top: 10px;
   left: 10px;
@@ -16,8 +16,8 @@
 
   .Nav__title {
     font-size: 25px;
-    border: 1px dashed blue;
     min-width: 175px;
+    cursor: default;
   }
 
   .Nav__MenuItems {
@@ -25,12 +25,22 @@
     flex-flow: row nowrap;
     justify-content: space-around;
     align-items: center;
-    border: 1px dashed green;
     width: 500px;
     height: 100%;
   }
 
-  .MenuLink {
-    border: 1px dashed green;
+  .MenuItem {
+    cursor: pointer;
+
+    &:hover {
+      color: orangered;
+    }
+  }
+
+  .MenuItems__signout {
+    color: orangered;
+     &:hover {
+       color: orange;
+     }
   }
 }

--- a/client/src/Components/Nav/Nav.test.js
+++ b/client/src/Components/Nav/Nav.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Nav from './Nav';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Nav />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});


### PR DESCRIPTION
# Description

Nav component:
- Add a basic Nav component
- Add initial styles to Nav component 

Map component:
- Add urls to additional map tiles in a object variable
- Add property on state to hold the map tile url
- Change react-leaflet Map component to use the map tile url on state (currently defaults to dark)
TODO: Add a setting somewhere that lets you choose between different maptiles 

**NOTE**: Disabled LandingPage & Settings component in `App.js` for ease of development. Should be able to change this back without breaking any new code.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
