### PR TITLE
Fix:  Zoom gets reset to initial value in state on click (issue #59)

### DIFF
--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -152,6 +152,11 @@ class MapComponent extends Component {
     }
   };
 
+  handleZoomend = e => {
+    const newZoomLevel = e.target._zoom;
+    this.setState({ zoom: newZoomLevel });
+  };
+
   render() {
     const position = [this.state.lat, this.state.lng];
 
@@ -162,10 +167,11 @@ class MapComponent extends Component {
         zoom={this.state.zoom}
         className="MapComponent"
         minZoom={2}
-        maxZoom={10}
+        maxZoom={12}
         maxBounds={bounds}
         onClick={this.handleClick}
         onMouseMove={this.handleMove}
+        onZoomend={this.handleZoomend}
       >
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"


### PR DESCRIPTION
# Description

- Map maintains current zoom level after clicking on a country.
- Increased max zoom size to mitigate issue with Popup falling outside of viewport.

Fixes #59 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested manually in browser
- All existing test pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
