### PR TITLE
Implement selecting different map themes

### DIFF
--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -141,10 +141,12 @@ module.exports = {
   login: async (req, res) => {
     try {
       // we only reach here because we are authenticated
+      const { id, username, countries, preferences } = req.user
       const user = {
-        id: req.user.id,
-        username: req.user.username,
-        countries: req.user.countries
+        id,
+        username,
+        countries,
+        preferences
       }; // add the things you need to send
       return res.status(200).json({ jwt_token: make_token(req.user), user });
     } catch (err) {

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -28,10 +28,10 @@ module.exports = {
         { new: true }
       );
 
-      res.status(200).json({ message: 'Email was updated successfully!' });
+      return res.status(200).json({ message: 'Email was updated successfully!' });
     } catch (err) {
       if (DEV) console.log(err);
-      res.status(500).json({ error: 'Failed to change email!' });
+      return res.status(500).json({ error: 'Failed to change email!' });
     }
   }, // change_email
 
@@ -43,7 +43,7 @@ module.exports = {
 
       // Check if password is the same as the old before updating
       if (await user.check_password(new_password)) {
-        res.status(400).json({ error: 'New password is the same as the old!' });
+        return res.status(400).json({ error: 'New password is the same as the old!' });
       } else {
         // hash new password (mongoose doesn't support pre update hooks)
         const password_hash = await argon2.hash(new_password);
@@ -55,11 +55,11 @@ module.exports = {
           { new: true }
         );
 
-        res.status(200).json({ message: 'Password was updated successfully!' });
+        return res.status(200).json({ message: 'Password was updated successfully!' });
       }
     } catch (err) {
       if (DEV) console.log(err);
-      res.status(500).json({ error: 'Failed to change password!' });
+      return res.status(500).json({ error: 'Failed to change password!' });
     }
   }, // change_password
 
@@ -68,7 +68,7 @@ module.exports = {
 
     // found an error, terminate
     if (check.error !== undefined) {
-      res.status(400).json(check);
+      return res.status(400).json(check);
       return;
     }
 
@@ -80,17 +80,17 @@ module.exports = {
 
       if (created_user) {
         // user creation was successful, send a jwt_token back
-        res.status(200).json({
+        return res.status(200).json({
           jwt_token: make_token(created_user),
           user: { id: created_user._id, username: created_user.username }
         });
       } else {
         if (DEV) console.log(err);
-        res.status(400).json({ error: 'failed user creation' });
+        return res.status(400).json({ error: 'failed user creation' });
       }
     } catch (err) {
       // if (DEV) console.log(err);
-      res.status(500).json({ error: 'failed user creation' });
+      return res.status(500).json({ error: 'failed user creation' });
     }
   }, // create_user
 
@@ -102,12 +102,12 @@ module.exports = {
         username: req.user.username,
         countries: req.user.countries
       }; // add the things you need to send
-      res.status(200).json({ jwt_token: make_token(req.user), user });
+      return res.status(200).json({ jwt_token: make_token(req.user), user });
     } catch (err) {
       if (DEV) {
         console.log(err);
       }
-      res.status(500).json({ error: 'Internal server error!' });
+      return res.status(500).json({ error: 'Internal server error!' });
     }
   }, // facebook_login
 
@@ -128,13 +128,13 @@ module.exports = {
     try {
       const foundUsers = await User.find({});
       if (foundUsers) {
-        res.status(200).json(foundUsers);
+        return res.status(200).json(foundUsers);
       } else {
-        res.status(400).json({ msg: 'No users found!' });
+        return res.status(400).json({ msg: 'No users found!' });
       }
     } catch (err) {
       if (DEV) console.log(err);
-      res.status(500).json({ error: 'Failed to get user!' });
+      return res.status(500).json({ error: 'Failed to get user!' });
     }
   },
 
@@ -174,7 +174,7 @@ module.exports = {
         { new: true }
       );
 
-      res.status(200).json(updatedUser);
+      return res.status(200).json(updatedUser);
     } catch (err) {
       if (DEV) console.log(err);
       return res.status(500).send({ error: 'Failed to update preferences' });

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
-import L from 'leaflet';
-import { Map, TileLayer, Marker, Popup, GeoJSON } from 'react-leaflet';
-import './Map.css';
-import geojson from './countries.geo.json';
+import { Map, TileLayer, Marker, GeoJSON } from 'react-leaflet';
 import wc from 'which-country';
+import geojson from './countries.geo.json';
 import {
   getCountryShapeFromCode,
   getCountryInfoFromCode
@@ -15,34 +13,7 @@ import {
 } from './countryStyles.js';
 import { mapTilesUrls, markerIcon, bounds } from './mapSetup.js';
 
-///* LEAFLET MAP SETUP START */
-//// Marker (workaround for an issue with react-leaflet)
-////TODO: Change to custom icon
-//const markerIcon = L.icon({
-//  iconUrl:
-//    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAApCAYAAADAk4LOAAAFgUlEQVR4Aa1XA5BjWRTN2oW17d3YaZtr2962HUzbDNpjszW24mRt28p47v7zq/bXZtrp/lWnXr337j3nPCe85NcypgSFdugCpW5YoDAMRaIMqRi6aKq5E3YqDQO3qAwjVWrD8Ncq/RBpykd8oZUb/kaJutow8r1aP9II0WmLKLIsJyv1w/kqw9Ch2MYdB++12Onxee/QMwvf4/Dk/Lfp/i4nxTXtOoQ4pW5Aj7wpici1A9erdAN2OH64x8OSP9j3Ft3b7aWkTg/Fm91siTra0f9on5sQr9INejH6CUUUpavjFNq1B+Oadhxmnfa8RfEmN8VNAsQhPqF55xHkMzz3jSmChWU6f7/XZKNH+9+hBLOHYozuKQPxyMPUKkrX/K0uWnfFaJGS1QPRtZsOPtr3NsW0uyh6NNCOkU3Yz+bXbT3I8G3xE5EXLXtCXbbqwCO9zPQYPRTZ5vIDXD7U+w7rFDEoUUf7ibHIR4y6bLVPXrz8JVZEql13trxwue/uDivd3fkWRbS6/IA2bID4uk0UpF1N8qLlbBlXs4Ee7HLTfV1j54APvODnSfOWBqtKVvjgLKzF5YdEk5ewRkGlK0i33Eofffc7HT56jD7/6U+qH3Cx7SBLNntH5YIPvODnyfIXZYRVDPqgHtLs5ABHD3YzLuespb7t79FY34DjMwrVrcTuwlT55YMPvOBnRrJ4VXTdNnYug5ucHLBjEpt30701A3Ts+HEa73u6dT3FNWwflY86eMHPk+Yu+i6pzUpRrW7SNDg5JHR4KapmM5Wv2E8Tfcb1HoqqHMHU+uWDD7zg54mz5/2BSnizi9T1Dg4QQXLToGNCkb6tb1NU+QAlGr1++eADrzhn/u8Q2YZhQVlZ5+CAOtqfbhmaUCS1ezNFVm2imDbPmPng5wmz+gwh+oHDce0eUtQ6OGDIyR0uUhUsoO3vfDmmgOezH0mZN59x7MBi++WDL1g/eEiU3avlidO671bkLfwbw5XV2P8Pzo0ydy4t2/0eu33xYSOMOD8hTf4CrBtGMSoXfPLchX+J0ruSePw3LZeK0juPJbYzrhkH0io7B3k164hiGvawhOKMLkrQLyVpZg8rHFW7E2uHOL888IBPlNZ1FPzstSJM694fWr6RwpvcJK60+0HCILTBzZLFNdtAzJaohze60T8qBzyh5ZuOg5e7uwQppofEmf2++DYvmySqGBuKaicF1blQjhuHdvCIMvp8whTTfZzI7RldpwtSzL+F1+wkdZ2TBOW2gIF88PBTzD/gpeREAMEbxnJcaJHNHrpzji0gQCS6hdkEeYt9DF/2qPcEC8RM28Hwmr3sdNyht00byAut2k3gufWNtgtOEOFGUwcXWNDbdNbpgBGxEvKkOQsxivJx33iow0Vw5S6SVTrpVq11ysA2Rp7gTfPfktc6zhtXBBC+adRLshf6sG2RfHPZ5EAc4sVZ83yCN00Fk/4kggu40ZTvIEm5g24qtU4KjBrx/BTTH8ifVASAG7gKrnWxJDcU7x8X6Ecczhm3o6YicvsLXWfh3Ch1W0k8x0nXF+0fFxgt4phz8QvypiwCCFKMqXCnqXExjq10beH+UUA7+nG6mdG/Pu0f3LgFcGrl2s0kNNjpmoJ9o4B29CMO8dMT4Q5ox8uitF6fqsrJOr8qnwNbRzv6hSnG5wP+64C7h9lp30hKNtKdWjtdkbuPA19nJ7Tz3zR/ibgARbhb4AlhavcBebmTHcFl2fvYEnW0ox9xMxKBS8btJ+KiEbq9zA4RthQXDhPa0T9TEe69gWupwc6uBUphquXgf+/FrIjweHQS4/pduMe5ERUMHUd9xv8ZR98CxkS4F2n3EUrUZ10EYNw7BWm9x1GiPssi3GgiGRDKWRYZfXlON+dfNbM+GgIwYdwAAAAASUVORK5CYII=',
-//  iconSize: [25, 40],
-//  iconAnchor: [0, 0],
-//  popupAnchor: [13, -4]
-//});
-
-//// Url's for different map tiles (active tile is set in component state)
-//const mapTilesUrls = {
-//  standard: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-//  toner: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
-//  terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
-//  watercolor: 'http://tile.stamen.com/watercolor/{z}/{x}/{y}.jpg',
-//  light:
-//    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
-//  dark:
-//    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
-//};
-
-//// Map bounds; set to maximum longitude and latitude
-//const corner1 = L.latLng(90, -180);
-//const corner2 = L.latLng(-90, 180);
-//const bounds = L.latLngBounds(corner1, corner2);
-///* LEAFLET MAP SETUP END */
+import './Map.css';
 
 /* MAIN MAP COMPONENT START */
 class MapComponent extends Component {
@@ -85,6 +56,11 @@ class MapComponent extends Component {
     const position = this.props.userPosition
       ? [this.props.userPosition.lat, this.props.userPosition.lng]
       : [0, 0];
+
+    const theme = this.props.user && this.props.user.preferences
+      ? this.props.user.preferences.theme
+      : 'dark';
+
     return (
       <Map
         center={position}
@@ -99,7 +75,7 @@ class MapComponent extends Component {
       >
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url={mapTilesUrls[this.props.user.preferences.theme]}
+          url={mapTilesUrls[theme]}
         />
 
         {/* Layers that will be active when a country is CLICKED */}

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -98,7 +98,7 @@ class MapComponent extends Component {
       >
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url={this.state.mapTile}
+          url={mapTilesUrls[this.props.user.preferences.theme]}
         />
 
         {/* Layers that will be active when a country is CLICKED */}

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -57,9 +57,10 @@ class MapComponent extends Component {
       ? [this.props.userPosition.lat, this.props.userPosition.lng]
       : [0, 0];
 
-    const theme = this.props.user && this.props.user.preferences
-      ? this.props.user.preferences.theme
-      : 'dark';
+    const theme =
+      this.props.user && this.props.user.preferences
+        ? this.props.user.preferences.theme
+        : 'dark';
 
     return (
       <Map
@@ -107,16 +108,15 @@ class MapComponent extends Component {
             )
         )}
 
-        {/* Render a layer for each country in the user object */}
+        {/* Render a layer for each country saved in user's 'countries' array */}
         {this.props.user && this.props.user.countries
           ? this.props.user.countries.map((country, i) => {
-              // get countries geojson shape
-              const countryShape = getCountryShapeFromCode(
-                country.country_code
-              );
-              // TODO: get style for corresponding status code
-              const style = countryStatusStyles[country.status_code];
-              // render geojson layer
+              const { country_code, status_code } = country;
+              // get geojson shape using helper function in `utils.js`
+              const countryShape = getCountryShapeFromCode(country_code);
+              // Get the corresponding style from status code from `countryStyles.js`
+              const style = countryStatusStyles[status_code];
+              // render geojson layer with the correct shape and style
               return <GeoJSON key={i} data={countryShape} style={style} />;
             })
           : null}

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -13,35 +13,36 @@ import {
   styleHover,
   countryStatusStyles
 } from './countryStyles.js';
+import { mapTilesUrls, markerIcon, bounds } from './mapSetup.js';
 
-/* LEAFLET MAP SETUP START */
-// Marker (workaround for an issue with react-leaflet)
-//TODO: Change to custom icon
-const markerIcon = L.icon({
-  iconUrl:
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAApCAYAAADAk4LOAAAFgUlEQVR4Aa1XA5BjWRTN2oW17d3YaZtr2962HUzbDNpjszW24mRt28p47v7zq/bXZtrp/lWnXr337j3nPCe85NcypgSFdugCpW5YoDAMRaIMqRi6aKq5E3YqDQO3qAwjVWrD8Ncq/RBpykd8oZUb/kaJutow8r1aP9II0WmLKLIsJyv1w/kqw9Ch2MYdB++12Onxee/QMwvf4/Dk/Lfp/i4nxTXtOoQ4pW5Aj7wpici1A9erdAN2OH64x8OSP9j3Ft3b7aWkTg/Fm91siTra0f9on5sQr9INejH6CUUUpavjFNq1B+Oadhxmnfa8RfEmN8VNAsQhPqF55xHkMzz3jSmChWU6f7/XZKNH+9+hBLOHYozuKQPxyMPUKkrX/K0uWnfFaJGS1QPRtZsOPtr3NsW0uyh6NNCOkU3Yz+bXbT3I8G3xE5EXLXtCXbbqwCO9zPQYPRTZ5vIDXD7U+w7rFDEoUUf7ibHIR4y6bLVPXrz8JVZEql13trxwue/uDivd3fkWRbS6/IA2bID4uk0UpF1N8qLlbBlXs4Ee7HLTfV1j54APvODnSfOWBqtKVvjgLKzF5YdEk5ewRkGlK0i33Eofffc7HT56jD7/6U+qH3Cx7SBLNntH5YIPvODnyfIXZYRVDPqgHtLs5ABHD3YzLuespb7t79FY34DjMwrVrcTuwlT55YMPvOBnRrJ4VXTdNnYug5ucHLBjEpt30701A3Ts+HEa73u6dT3FNWwflY86eMHPk+Yu+i6pzUpRrW7SNDg5JHR4KapmM5Wv2E8Tfcb1HoqqHMHU+uWDD7zg54mz5/2BSnizi9T1Dg4QQXLToGNCkb6tb1NU+QAlGr1++eADrzhn/u8Q2YZhQVlZ5+CAOtqfbhmaUCS1ezNFVm2imDbPmPng5wmz+gwh+oHDce0eUtQ6OGDIyR0uUhUsoO3vfDmmgOezH0mZN59x7MBi++WDL1g/eEiU3avlidO671bkLfwbw5XV2P8Pzo0ydy4t2/0eu33xYSOMOD8hTf4CrBtGMSoXfPLchX+J0ruSePw3LZeK0juPJbYzrhkH0io7B3k164hiGvawhOKMLkrQLyVpZg8rHFW7E2uHOL888IBPlNZ1FPzstSJM694fWr6RwpvcJK60+0HCILTBzZLFNdtAzJaohze60T8qBzyh5ZuOg5e7uwQppofEmf2++DYvmySqGBuKaicF1blQjhuHdvCIMvp8whTTfZzI7RldpwtSzL+F1+wkdZ2TBOW2gIF88PBTzD/gpeREAMEbxnJcaJHNHrpzji0gQCS6hdkEeYt9DF/2qPcEC8RM28Hwmr3sdNyht00byAut2k3gufWNtgtOEOFGUwcXWNDbdNbpgBGxEvKkOQsxivJx33iow0Vw5S6SVTrpVq11ysA2Rp7gTfPfktc6zhtXBBC+adRLshf6sG2RfHPZ5EAc4sVZ83yCN00Fk/4kggu40ZTvIEm5g24qtU4KjBrx/BTTH8ifVASAG7gKrnWxJDcU7x8X6Ecczhm3o6YicvsLXWfh3Ch1W0k8x0nXF+0fFxgt4phz8QvypiwCCFKMqXCnqXExjq10beH+UUA7+nG6mdG/Pu0f3LgFcGrl2s0kNNjpmoJ9o4B29CMO8dMT4Q5ox8uitF6fqsrJOr8qnwNbRzv6hSnG5wP+64C7h9lp30hKNtKdWjtdkbuPA19nJ7Tz3zR/ibgARbhb4AlhavcBebmTHcFl2fvYEnW0ox9xMxKBS8btJ+KiEbq9zA4RthQXDhPa0T9TEe69gWupwc6uBUphquXgf+/FrIjweHQS4/pduMe5ERUMHUd9xv8ZR98CxkS4F2n3EUrUZ10EYNw7BWm9x1GiPssi3GgiGRDKWRYZfXlON+dfNbM+GgIwYdwAAAAASUVORK5CYII=',
-  iconSize: [25, 40],
-  iconAnchor: [0, 0],
-  popupAnchor: [13, -4]
-});
+///* LEAFLET MAP SETUP START */
+//// Marker (workaround for an issue with react-leaflet)
+////TODO: Change to custom icon
+//const markerIcon = L.icon({
+//  iconUrl:
+//    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAApCAYAAADAk4LOAAAFgUlEQVR4Aa1XA5BjWRTN2oW17d3YaZtr2962HUzbDNpjszW24mRt28p47v7zq/bXZtrp/lWnXr337j3nPCe85NcypgSFdugCpW5YoDAMRaIMqRi6aKq5E3YqDQO3qAwjVWrD8Ncq/RBpykd8oZUb/kaJutow8r1aP9II0WmLKLIsJyv1w/kqw9Ch2MYdB++12Onxee/QMwvf4/Dk/Lfp/i4nxTXtOoQ4pW5Aj7wpici1A9erdAN2OH64x8OSP9j3Ft3b7aWkTg/Fm91siTra0f9on5sQr9INejH6CUUUpavjFNq1B+Oadhxmnfa8RfEmN8VNAsQhPqF55xHkMzz3jSmChWU6f7/XZKNH+9+hBLOHYozuKQPxyMPUKkrX/K0uWnfFaJGS1QPRtZsOPtr3NsW0uyh6NNCOkU3Yz+bXbT3I8G3xE5EXLXtCXbbqwCO9zPQYPRTZ5vIDXD7U+w7rFDEoUUf7ibHIR4y6bLVPXrz8JVZEql13trxwue/uDivd3fkWRbS6/IA2bID4uk0UpF1N8qLlbBlXs4Ee7HLTfV1j54APvODnSfOWBqtKVvjgLKzF5YdEk5ewRkGlK0i33Eofffc7HT56jD7/6U+qH3Cx7SBLNntH5YIPvODnyfIXZYRVDPqgHtLs5ABHD3YzLuespb7t79FY34DjMwrVrcTuwlT55YMPvOBnRrJ4VXTdNnYug5ucHLBjEpt30701A3Ts+HEa73u6dT3FNWwflY86eMHPk+Yu+i6pzUpRrW7SNDg5JHR4KapmM5Wv2E8Tfcb1HoqqHMHU+uWDD7zg54mz5/2BSnizi9T1Dg4QQXLToGNCkb6tb1NU+QAlGr1++eADrzhn/u8Q2YZhQVlZ5+CAOtqfbhmaUCS1ezNFVm2imDbPmPng5wmz+gwh+oHDce0eUtQ6OGDIyR0uUhUsoO3vfDmmgOezH0mZN59x7MBi++WDL1g/eEiU3avlidO671bkLfwbw5XV2P8Pzo0ydy4t2/0eu33xYSOMOD8hTf4CrBtGMSoXfPLchX+J0ruSePw3LZeK0juPJbYzrhkH0io7B3k164hiGvawhOKMLkrQLyVpZg8rHFW7E2uHOL888IBPlNZ1FPzstSJM694fWr6RwpvcJK60+0HCILTBzZLFNdtAzJaohze60T8qBzyh5ZuOg5e7uwQppofEmf2++DYvmySqGBuKaicF1blQjhuHdvCIMvp8whTTfZzI7RldpwtSzL+F1+wkdZ2TBOW2gIF88PBTzD/gpeREAMEbxnJcaJHNHrpzji0gQCS6hdkEeYt9DF/2qPcEC8RM28Hwmr3sdNyht00byAut2k3gufWNtgtOEOFGUwcXWNDbdNbpgBGxEvKkOQsxivJx33iow0Vw5S6SVTrpVq11ysA2Rp7gTfPfktc6zhtXBBC+adRLshf6sG2RfHPZ5EAc4sVZ83yCN00Fk/4kggu40ZTvIEm5g24qtU4KjBrx/BTTH8ifVASAG7gKrnWxJDcU7x8X6Ecczhm3o6YicvsLXWfh3Ch1W0k8x0nXF+0fFxgt4phz8QvypiwCCFKMqXCnqXExjq10beH+UUA7+nG6mdG/Pu0f3LgFcGrl2s0kNNjpmoJ9o4B29CMO8dMT4Q5ox8uitF6fqsrJOr8qnwNbRzv6hSnG5wP+64C7h9lp30hKNtKdWjtdkbuPA19nJ7Tz3zR/ibgARbhb4AlhavcBebmTHcFl2fvYEnW0ox9xMxKBS8btJ+KiEbq9zA4RthQXDhPa0T9TEe69gWupwc6uBUphquXgf+/FrIjweHQS4/pduMe5ERUMHUd9xv8ZR98CxkS4F2n3EUrUZ10EYNw7BWm9x1GiPssi3GgiGRDKWRYZfXlON+dfNbM+GgIwYdwAAAAASUVORK5CYII=',
+//  iconSize: [25, 40],
+//  iconAnchor: [0, 0],
+//  popupAnchor: [13, -4]
+//});
 
-// Url's for different map tiles (active tile is set in component state)
-const mapTilesUrls = {
-  standard: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-  toner: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
-  terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
-  watercolor: 'http://tile.stamen.com/watercolor/{z}/{x}/{y}.jpg',
-  light:
-    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
-  dark:
-    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
-};
+//// Url's for different map tiles (active tile is set in component state)
+//const mapTilesUrls = {
+//  standard: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+//  toner: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+//  terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+//  watercolor: 'http://tile.stamen.com/watercolor/{z}/{x}/{y}.jpg',
+//  light:
+//    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+//  dark:
+//    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
+//};
 
-// Map bounds; set to maximum longitude and latitude
-const corner1 = L.latLng(90, -180);
-const corner2 = L.latLng(-90, 180);
-const bounds = L.latLngBounds(corner1, corner2);
-/* LEAFLET MAP SETUP END */
+//// Map bounds; set to maximum longitude and latitude
+//const corner1 = L.latLng(90, -180);
+//const corner2 = L.latLng(-90, 180);
+//const bounds = L.latLngBounds(corner1, corner2);
+///* LEAFLET MAP SETUP END */
 
 /* MAIN MAP COMPONENT START */
 class MapComponent extends Component {

--- a/client/src/Components/Map/mapSetup.js
+++ b/client/src/Components/Map/mapSetup.js
@@ -1,0 +1,30 @@
+import L from 'leaflet';
+
+/* LEAFLET MAP SETUP START */
+// Marker (workaround for an issue with react-leaflet)
+//TODO: Change to custom icon
+export const markerIcon = L.icon({
+  iconUrl:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAApCAYAAADAk4LOAAAFgUlEQVR4Aa1XA5BjWRTN2oW17d3YaZtr2962HUzbDNpjszW24mRt28p47v7zq/bXZtrp/lWnXr337j3nPCe85NcypgSFdugCpW5YoDAMRaIMqRi6aKq5E3YqDQO3qAwjVWrD8Ncq/RBpykd8oZUb/kaJutow8r1aP9II0WmLKLIsJyv1w/kqw9Ch2MYdB++12Onxee/QMwvf4/Dk/Lfp/i4nxTXtOoQ4pW5Aj7wpici1A9erdAN2OH64x8OSP9j3Ft3b7aWkTg/Fm91siTra0f9on5sQr9INejH6CUUUpavjFNq1B+Oadhxmnfa8RfEmN8VNAsQhPqF55xHkMzz3jSmChWU6f7/XZKNH+9+hBLOHYozuKQPxyMPUKkrX/K0uWnfFaJGS1QPRtZsOPtr3NsW0uyh6NNCOkU3Yz+bXbT3I8G3xE5EXLXtCXbbqwCO9zPQYPRTZ5vIDXD7U+w7rFDEoUUf7ibHIR4y6bLVPXrz8JVZEql13trxwue/uDivd3fkWRbS6/IA2bID4uk0UpF1N8qLlbBlXs4Ee7HLTfV1j54APvODnSfOWBqtKVvjgLKzF5YdEk5ewRkGlK0i33Eofffc7HT56jD7/6U+qH3Cx7SBLNntH5YIPvODnyfIXZYRVDPqgHtLs5ABHD3YzLuespb7t79FY34DjMwrVrcTuwlT55YMPvOBnRrJ4VXTdNnYug5ucHLBjEpt30701A3Ts+HEa73u6dT3FNWwflY86eMHPk+Yu+i6pzUpRrW7SNDg5JHR4KapmM5Wv2E8Tfcb1HoqqHMHU+uWDD7zg54mz5/2BSnizi9T1Dg4QQXLToGNCkb6tb1NU+QAlGr1++eADrzhn/u8Q2YZhQVlZ5+CAOtqfbhmaUCS1ezNFVm2imDbPmPng5wmz+gwh+oHDce0eUtQ6OGDIyR0uUhUsoO3vfDmmgOezH0mZN59x7MBi++WDL1g/eEiU3avlidO671bkLfwbw5XV2P8Pzo0ydy4t2/0eu33xYSOMOD8hTf4CrBtGMSoXfPLchX+J0ruSePw3LZeK0juPJbYzrhkH0io7B3k164hiGvawhOKMLkrQLyVpZg8rHFW7E2uHOL888IBPlNZ1FPzstSJM694fWr6RwpvcJK60+0HCILTBzZLFNdtAzJaohze60T8qBzyh5ZuOg5e7uwQppofEmf2++DYvmySqGBuKaicF1blQjhuHdvCIMvp8whTTfZzI7RldpwtSzL+F1+wkdZ2TBOW2gIF88PBTzD/gpeREAMEbxnJcaJHNHrpzji0gQCS6hdkEeYt9DF/2qPcEC8RM28Hwmr3sdNyht00byAut2k3gufWNtgtOEOFGUwcXWNDbdNbpgBGxEvKkOQsxivJx33iow0Vw5S6SVTrpVq11ysA2Rp7gTfPfktc6zhtXBBC+adRLshf6sG2RfHPZ5EAc4sVZ83yCN00Fk/4kggu40ZTvIEm5g24qtU4KjBrx/BTTH8ifVASAG7gKrnWxJDcU7x8X6Ecczhm3o6YicvsLXWfh3Ch1W0k8x0nXF+0fFxgt4phz8QvypiwCCFKMqXCnqXExjq10beH+UUA7+nG6mdG/Pu0f3LgFcGrl2s0kNNjpmoJ9o4B29CMO8dMT4Q5ox8uitF6fqsrJOr8qnwNbRzv6hSnG5wP+64C7h9lp30hKNtKdWjtdkbuPA19nJ7Tz3zR/ibgARbhb4AlhavcBebmTHcFl2fvYEnW0ox9xMxKBS8btJ+KiEbq9zA4RthQXDhPa0T9TEe69gWupwc6uBUphquXgf+/FrIjweHQS4/pduMe5ERUMHUd9xv8ZR98CxkS4F2n3EUrUZ10EYNw7BWm9x1GiPssi3GgiGRDKWRYZfXlON+dfNbM+GgIwYdwAAAAASUVORK5CYII=',
+  iconSize: [25, 40],
+  iconAnchor: [0, 0],
+  popupAnchor: [13, -4]
+});
+
+// Url's for different map tiles (active tile is set in component state)
+export const mapTilesUrls = {
+  standard: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  toner: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+  terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+  watercolor: 'http://tile.stamen.com/watercolor/{z}/{x}/{y}.jpg',
+  light:
+    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+  dark:
+    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
+};
+
+// Map bounds; set to maximum longitude and latitude
+const corner1 = L.latLng(90, -180);
+const corner2 = L.latLng(-90, 180);
+export const bounds = L.latLngBounds(corner1, corner2);
+/* LEAFLET MAP SETUP END */

--- a/client/src/Components/Settings/Preferences.js
+++ b/client/src/Components/Settings/Preferences.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import mapTilesUrls from '../Map/mapSetup.js';
 
 import './Preferences.css';
 

--- a/client/src/Components/Settings/Preferences.js
+++ b/client/src/Components/Settings/Preferences.js
@@ -36,6 +36,9 @@ class Preferences extends Component {
           >
             <option value="light">light</option>
             <option value="dark">dark</option>
+            <option value="watercolor">watercolor</option>
+            <option value="toner">toner</option>
+            <option value="standard">standard</option>
           </select>
         </div>
 

--- a/client/src/Components/Settings/Preferences.js
+++ b/client/src/Components/Settings/Preferences.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import mapTilesUrls from '../Map/mapSetup.js';
 
 import './Preferences.css';
 
@@ -18,14 +19,23 @@ class Preferences extends Component {
   };
 
   render() {
+    const theme =
+      this.props.user && this.props.user.preferences
+        ? this.props.user.preferences.theme
+        : 'dark';
     return (
       <div className="Settings__Preferences">
         <h4>Preferences</h4>
         <div className="Preferences__theme">
           <h5>Theme</h5>
-          <select className="Theme" name="theme" onChange={this.handleChange}>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
+          <select
+            className="Theme"
+            defaultValue={theme}
+            name="theme"
+            onChange={this.handleChange}
+          >
+            <option value="light">light</option>
+            <option value="dark">dark</option>
           </select>
         </div>
 


### PR DESCRIPTION
# Description

- Allows user to select a theme/mapTile
- Selected theme/mapTile is saved to `preferences` field on `User` model
- Theme dropdown uses the current theme the user has saved as the default value
- Theme persists across sessions
- Moved `Map` related setup and `mapTilesUrls` to `mapSetup.js`

**NOTE**:
Currently requires a manual refresh for new theme to take affect. We will need to decide how to deal with that. Some ideas:
- Notify the user a page refresh is required
- Force a page refresh
- Update user settings on AppContext (this might not work, depending on how leaflet handles dynamically changing the tile layer)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested locally with browser (make sure you refresh page after clicking 'apply')
- All existing test pass
**NOTE**: You will need to test using an account that was created after the `User` schema was modified to add a `preferences` field. Otherwise it _should_ default to the 'dark' theme.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
