### PR TITLE
Add protected_route middleware for country_status route

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -55,7 +55,7 @@ module.exports = server => {
     .get(facebook_authentication_callback, facebook_loggedIn);
 
   // Country Status Route
-  server.route('/api/country_status').post(handle_status);
+  server.route('/api/country_status').post(protected_route, handle_status);
 
   // Update settings
   server.route('/api/change_password').put(protected_route, change_password);

--- a/client/src/AppContext.js
+++ b/client/src/AppContext.js
@@ -123,7 +123,7 @@ export class AppContextProvider extends Component {
           response.status,
           response.data
         );
-        this.setState({ user: response.data })
+        this.setState({ user: response.data });
       }
 
       if (response.status === 400)
@@ -153,6 +153,7 @@ export class AppContextProvider extends Component {
   handleSliderMove = async value => {
     try {
       const { user, currentCountry } = this.state;
+
       const body = {
         username: user.username,
         country_code: currentCountry.code,
@@ -160,20 +161,30 @@ export class AppContextProvider extends Component {
         status_code: value
       };
 
-      const response = await axios.post(`${BACKEND_URL}/country_status`, body);
+      const options = {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('token')}`
+        }
+      };
+
+      const response = await axios.post(
+        `${BACKEND_URL}/country_status`,
+        body,
+        options
+      );
 
       // Clear user on state first as a workaround for the following issue:
       //    Updating an existing country would not update the color
       //    Clearing the user on state first forces the geojson layer to re-render
       // This is because React is not detecting changes in nested objects.
-      // TODO: Store users' countries as an array on AppState (not inside user)
+      // TODO: Refactor to store users' countries as an array on AppState (not inside user)
       this.setState({ user: {} });
       this.setState({ user: response.data });
       this.setState({ currentCountryStatus: this.getCurrentCountryStatus() });
     } catch (err) {
       console.error('Error updating country status!');
     }
-  };
+  }; // handleSliderMove
 
   handleSignIn = async e => {
     e.preventDefault();
@@ -188,7 +199,7 @@ export class AppContextProvider extends Component {
       localStorage.setItem('user', user);
       this.setState({
         authenticated: true,
-        user: { ...response.data.user },
+        user: { ...response.data.user }
       });
     } catch (e) {
       // failed async


### PR DESCRIPTION
# Description

- Retrieve token and send in headers with axios call when slider is moved
- Insert `protected_route` middleware in `country_status` route

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested manually with browser
- All existing tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
