### PR TITLE
change_email/change_password tests

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -349,12 +349,13 @@ describe('User', () => {
 
   describe('PUT routes', () => {
     describe('/change_email', () => {
-      it('succeeds with a valid token and username', async () => {
+      const body = {
+        new_email: 'newEmail@email.com'
+      };
+
+      it('succeeds with a valid token', async () => {
         const { jwt_token } = initialTestUser.body;
 
-        const body = {
-          new_email: 'newEmail@email.com'
-        };
         const response = await request(server)
           .put('/api/change_email')
           .set('Authorization', `Bearer ${jwt_token}`)
@@ -367,12 +368,8 @@ describe('User', () => {
       });
 
       it('fails if a token is not supplied', async () => {
-        const { user, jwt_token } = initialTestUser.body;
+        const { jwt_token } = initialTestUser.body;
 
-        const body = {
-          username: user.username,
-          new_email: 'newEmail@email.com'
-        };
         const response = await request(server)
           .put('/api/change_email')
           .send(body);
@@ -386,10 +383,6 @@ describe('User', () => {
           .split('')
           .reverse()
           .join('');
-
-        const body = {
-          new_email: 'newEmail@email.com'
-        };
 
         const response = await request(server)
           .put('/api/change_email')

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -394,7 +394,24 @@ describe('User', () => {
       });
     });
 
-    // TODO: Add tests for change_password
+    describe('/change_password', () => {
+      const body = {
+        username: 'initialTestUser',
+        new_password: '654321'
+      }
+      it('updates password correctly', async () => {
+        const { jwt_token } = initialTestUser.body;
+        const response = await request(server)
+          .put('/api/change_password')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send(body);
+
+        expect(response.status).toBe(200);
+        expect(body.new_password).toEqual('654321');
+      })
+    })
+
+
     describe('/update_preferences', () => {
       it('updates user correctly', async () => {
         const testUserInfo = {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -350,10 +350,9 @@ describe('User', () => {
   describe('PUT routes', () => {
     describe('/change_email', () => {
       it('succeeds with a valid token and username', async () => {
-        const { user, jwt_token } = initialTestUser.body;
+        const { jwt_token } = initialTestUser.body;
 
         const body = {
-          username: user.username,
           new_email: 'newEmail@email.com'
         };
         const response = await request(server)
@@ -367,7 +366,7 @@ describe('User', () => {
         );
       });
 
-      it('fails without a valid token', async () => {
+      it('fails if a token is not supplied', async () => {
         const { user, jwt_token } = initialTestUser.body;
 
         const body = {
@@ -376,6 +375,25 @@ describe('User', () => {
         };
         const response = await request(server)
           .put('/api/change_email')
+          .send(body);
+
+        expect(response.status).toBe(401);
+        expect(response.error).toBeDefined();
+      });
+
+      it('fails with an invalid token', async () => {
+        const jwt_token = initialTestUser.body.jwt_token
+          .split('')
+          .reverse()
+          .join('');
+
+        const body = {
+          new_email: 'newEmail@email.com'
+        };
+
+        const response = await request(server)
+          .put('/api/change_email')
+          .set('Authorization', `Bearer ${jwt_token}`)
           .send(body);
 
         expect(response.status).toBe(401);

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -448,7 +448,7 @@ describe('User', () => {
     });
 
     describe('/update_preferences', () => {
-      it('updates user correctly', async () => {
+      it('updates preferences correctly', async () => {
         const updatedPreferences = {
           preferences: {
             theme: 'light',
@@ -465,6 +465,42 @@ describe('User', () => {
         expect(response.body.username).toBeDefined();
         expect(response.body.preferences.theme).toBe('light');
         expect(response.body.preferences.autoscratch).toBe(false);
+      });
+
+      it('fails if no token is supplied', async () => {
+        const updatedPreferences = {
+          preferences: {
+            theme: 'light',
+            autoscratch: false
+          }
+        };
+
+        const response = await request(server)
+          .put(`/api/update_preferences`)
+          .send(updatedPreferences);
+
+        expect(response.status).toBe(401);
+        expect(response.body.username).toBeUndefined();
+        expect(response.body.preferences).toBeUndefined();
+      });
+
+      it('fails if invalid token is supplied', async () => {
+        const invalid_token = initialTestUser.body.jwt_token.slice(1)
+        const updatedPreferences = {
+          preferences: {
+            theme: 'light',
+            autoscratch: false
+          }
+        };
+
+        const response = await request(server)
+          .put(`/api/update_preferences`)
+          .set('Authorization', `Bearer ${invalid_token}`)
+          .send(updatedPreferences);
+
+        expect(response.status).toBe(401);
+        expect(response.body.username).toBeUndefined();
+        expect(response.body.preferences).toBeUndefined();
       });
 
       it('rejects request if preferences is not provided', async () => {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -348,9 +348,43 @@ describe('User', () => {
   });
 
   describe('PUT routes', () => {
+    describe('/change_email', () => {
+      it('succeeds with a valid token and username', async () => {
+        const { user, jwt_token } = initialTestUser.body;
+
+        const body = {
+          username: user.username,
+          new_email: 'newEmail@email.com'
+        };
+        const response = await request(server)
+          .put('/api/change_email')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send(body);
+
+        expect(response.status).toBe(200);
+        expect(response.body.message).toEqual(
+          'Email was updated successfully!'
+        );
+      });
+
+      it('fails without a valid token', async () => {
+        const { user, jwt_token } = initialTestUser.body;
+
+        const body = {
+          username: user.username,
+          new_email: 'newEmail@email.com'
+        };
+        const response = await request(server)
+          .put('/api/change_email')
+          .send(body);
+
+        expect(response.status).toBe(401);
+        expect(response.error).toBeDefined();
+      });
+    });
+
+    // TODO: Add tests for change_password
     describe('/update_preferences', () => {
-      // TODO: Add tests for change_email
-      // TODO: Add tests for change_password
       it('updates user correctly', async () => {
         const testUserInfo = {
           username: 'updatepreferences1',

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -449,19 +449,7 @@ describe('User', () => {
 
     describe('/update_preferences', () => {
       it('updates user correctly', async () => {
-        const testUserInfo = {
-          username: 'updatepreferences1',
-          password: '123456',
-          email: 'update_preferences1@test.com'
-        };
-
-        const newUser = await request(server)
-          .post(`/api/register`)
-          .send(testUserInfo);
-        expect(newUser.status).toBe(200);
-
         const updatedPreferences = {
-          username: 'updatepreferences1',
           preferences: {
             theme: 'light',
             autoscratch: false
@@ -470,37 +458,20 @@ describe('User', () => {
 
         const response = await request(server)
           .put(`/api/update_preferences`)
-          .set('Authorization', `Bearer ${newUser.body.jwt_token}`)
+          .set('Authorization', `Bearer ${initialTestUser.body.jwt_token}`)
           .send(updatedPreferences);
 
         expect(response.status).toBe(200);
-        expect(response.body).toBeDefined();
         expect(response.body.username).toBeDefined();
-        expect(response.body.preferences).toBeDefined();
         expect(response.body.preferences.theme).toBe('light');
         expect(response.body.preferences.autoscratch).toBe(false);
       });
 
       it('rejects request if preferences is not provided', async () => {
-        const testUserInfo = {
-          username: 'updatepreferences2',
-          password: '123456',
-          email: 'update_preferences2@test.com'
-        };
-
-        const newUser = await request(server)
-          .post(`/api/register`)
-          .send(testUserInfo);
-        expect(newUser.status).toBe(200);
-
-        const updatedPreferences = {
-          username: 'updatepreferences2'
-        };
-
         const response = await request(server)
           .put(`/api/update_preferences`)
-          .set('Authorization', `Bearer ${newUser.body.jwt_token}`)
-          .send(updatedPreferences);
+          .set('Authorization', `Bearer ${initialTestUser.body.jwt_token}`)
+          .send({});
 
         expect(response.status).toBe(400);
         expect(response.body.username).toBeUndefined();

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -70,20 +70,7 @@ describe('User', () => {
         expect(response.status).toBe(200);
       });
 
-      it('fails with an invalid password', async () => {
-        const user = {
-          username: 'Pikachu',
-          password: 'p',
-          email: 'pika@gmail.com'
-        };
-        const response = await request(server)
-          .post('/api/register')
-          .send(user);
-
-        expect(response.status).toBe(400);
-      });
-
-      it('fails with an undefined password', async () => {
+      it('fails if password is not provided', async () => {
         const user = { username: 'Pikachu', email: 'pika@gmail.com' };
         const response = await request(server)
           .post('/api/register')
@@ -92,7 +79,21 @@ describe('User', () => {
         expect(response.status).toBe(400);
       });
 
-      it('fails with an undefined username', async () => {
+      it('fails if password is not valid', async () => {
+        const user = {
+          username: 'Pikachu',
+          password: 'p',
+          email: 'pika@gmail.com'
+        };
+
+        const response = await request(server)
+          .post('/api/register')
+          .send(user);
+
+        expect(response.status).toBe(400);
+      });
+
+      it('fails if username is not provided', async () => {
         const user = { password: 'pasdfsadfasdfsdf', email: 'pika@gmail.com' };
         const response = await request(server)
           .post('/api/register')
@@ -101,16 +102,7 @@ describe('User', () => {
         expect(response.status).toBe(400);
       });
 
-      it('fails with an undefined email', async () => {
-        const user = { username: 'Pikachu', password: 'pasdfsadfasdfsdf' };
-        const response = await request(server)
-          .post('/api/register')
-          .send(user);
-
-        expect(response.status).toBe(400);
-      });
-
-      it('fails with a non-unique username', async () => {
+      it('fails if username is not unique', async () => {
         const user1 = {
           username: 'Pikachu',
           password: 'pasdfsadfasdfsdf',
@@ -135,7 +127,16 @@ describe('User', () => {
         expect(response2.status).toBe(500);
       });
 
-      it('fails with a non-unique email', async () => {
+      it('fails if email is not provided', async () => {
+        const user = { username: 'Pikachu', password: 'pasdfsadfasdfsdf' };
+        const response = await request(server)
+          .post('/api/register')
+          .send(user);
+
+        expect(response.status).toBe(400);
+      });
+
+      it('fails if email is not unique', async () => {
         const user1 = {
           username: 'Frodo',
           password: 'pasdfsadfasdfsdf',
@@ -193,7 +194,26 @@ describe('User', () => {
         username: 'initialTestUser'
       };
 
-      it('updates an existing country correctly', async () => {
+      it('successfully adds a new country if it does not exist', async () => {
+        const { jwt_token, user } = initialTestUser.body;
+        expect(jwt_token).toBeDefined();
+        expect(user.username).toBe('initialTestUser');
+        expect(user.id).toBeDefined();
+        expect(user.countries.length).toBe(0);
+
+        const response = await request(server)
+          .post('/api/country_status')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send(new_country_status);
+
+        expect(response.body.countries.length).toBe(1);
+        expect(response.body.countries[0]).toBeDefined();
+        expect(response.body.countries[0].country_code).toBe('CHN');
+        expect(response.body.countries[0].status_code).toBe(1);
+        expect(response.body.countries[0].name).toBe('China');
+      });
+
+      it('successfully updates an existing country', async () => {
         const { jwt_token, user } = initialTestUser.body;
         expect(jwt_token).toBeDefined();
         expect(user.username).toBe('initialTestUser');
@@ -228,7 +248,7 @@ describe('User', () => {
         expect(response_2.body.countries[0].name).toBe('China');
       });
 
-      it('fails without a token', async () => {
+      it('fails if no token is provided', async () => {
         const response = await request(server)
           .post('/api/country_status')
           .send(new_country_status);
@@ -238,7 +258,7 @@ describe('User', () => {
         expect(response.body.countries).toBeUndefined();
       });
 
-      it('fails with an invalid token', async () => {
+      it('fails if invalid token is provided', async () => {
         const jwt_token = initialTestUser.body.jwt_token
           .split('')
           .reverse()
@@ -252,25 +272,6 @@ describe('User', () => {
         expect(response.status).toBe(401);
         expect(response.body.username).toBeUndefined();
         expect(response.body.countries).toBeUndefined();
-      });
-
-      it('adds a new country if it does not already exist', async () => {
-        const { jwt_token, user } = initialTestUser.body;
-        expect(jwt_token).toBeDefined();
-        expect(user.username).toBe('initialTestUser');
-        expect(user.id).toBeDefined();
-        expect(user.countries.length).toBe(0);
-
-        const response = await request(server)
-          .post('/api/country_status')
-          .set('Authorization', `Bearer ${jwt_token}`)
-          .send(new_country_status);
-
-        expect(response.body.countries.length).toBe(1);
-        expect(response.body.countries[0]).toBeDefined();
-        expect(response.body.countries[0].country_code).toBe('CHN');
-        expect(response.body.countries[0].status_code).toBe(1);
-        expect(response.body.countries[0].name).toBe('China');
       });
     });
   });
@@ -301,7 +302,7 @@ describe('User', () => {
         expect(getUser.body.email).toBe('getuser1@test.com');
       });
 
-      it('fails without a token', async () => {
+      it('fails if no token is provided', async () => {
         const testUserInfo = {
           username: 'getuser2',
           password: '123456',
@@ -322,7 +323,7 @@ describe('User', () => {
         expect(getUser.body.email).toBeUndefined();
       });
 
-      it('fails with an invalid token', async () => {
+      it('fails if invalid token is provided', async () => {
         const testUserInfo = {
           username: 'getuser3',
           password: '123456',
@@ -367,7 +368,7 @@ describe('User', () => {
         );
       });
 
-      it('fails if a token is not supplied', async () => {
+      it('fails if no token is provided', async () => {
         const { jwt_token } = initialTestUser.body;
 
         const response = await request(server)
@@ -378,7 +379,7 @@ describe('User', () => {
         expect(response.error).toBeDefined();
       });
 
-      it('fails with an invalid token', async () => {
+      it('fails if invalid token is provided', async () => {
         const jwt_token = initialTestUser.body.jwt_token
           .split('')
           .reverse()
@@ -409,7 +410,7 @@ describe('User', () => {
         expect(body.new_password).toEqual('654321');
       });
 
-      it('fails if no token is supplied', async () => {
+      it('fails if no token is provided', async () => {
         const response = await request(server)
           .put('/api/change_password')
           .send({ new_password: initialTestUserInfo.password });
@@ -418,7 +419,7 @@ describe('User', () => {
         expect(response.error).toBeDefined();
       });
 
-      it('fails if invalid token is supplied', async () => {
+      it('fails if invalid token is provided', async () => {
         const jwt_token = initialTestUser.body.jwt_token
           .split('')
           .reverse()
@@ -467,7 +468,7 @@ describe('User', () => {
         expect(response.body.preferences.autoscratch).toBe(false);
       });
 
-      it('fails if no token is supplied', async () => {
+      it('fails if no token is provided', async () => {
         const updatedPreferences = {
           preferences: {
             theme: 'light',
@@ -484,7 +485,7 @@ describe('User', () => {
         expect(response.body.preferences).toBeUndefined();
       });
 
-      it('fails if invalid token is supplied', async () => {
+      it('fails if invalid token is provided', async () => {
         const invalid_token = initialTestUser.body.jwt_token.slice(1);
         const updatedPreferences = {
           preferences: {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -396,7 +396,6 @@ describe('User', () => {
 
     describe('/change_password', () => {
       const body = {
-        username: 'initialTestUser',
         new_password: '654321'
       }
       it('updates password correctly', async () => {
@@ -410,7 +409,6 @@ describe('User', () => {
         expect(body.new_password).toEqual('654321');
       })
     })
-
 
     describe('/update_preferences', () => {
       it('updates user correctly', async () => {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -506,35 +506,6 @@ describe('User', () => {
         expect(response.body.username).toBeUndefined();
         expect(response.body.preferences).toBeUndefined();
       });
-
-      it('rejects request if username is not provided', async () => {
-        const testUserInfo = {
-          username: 'updatepreferences3',
-          password: '123456',
-          email: 'update_preferences3@test.com'
-        };
-
-        const newUser = await request(server)
-          .post(`/api/register`)
-          .send(testUserInfo);
-        expect(newUser.status).toBe(200);
-
-        const updatedPreferences = {
-          preferences: {
-            theme: 'light',
-            autoscratch: false
-          }
-        };
-
-        const response = await request(server)
-          .put(`/api/update_preferences`)
-          .set('Authorization', `Bearer ${newUser.body.jwt_token}`)
-          .send(updatedPreferences);
-
-        expect(response.status).toBe(400);
-        expect(response.body.username).toBeUndefined();
-        expect(response.body.preferences).toBeUndefined();
-      });
     });
   });
 });

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -29,9 +29,10 @@ module.exports = {
 
       console.log(response);
       if (response)
-        return res.status(200).json({ message: 'Email was updated successfully!' });
-      else
-        return res.status(400).json({ message: 'Failed to update email!' })
+        return res
+          .status(200)
+          .json({ message: 'Email was updated successfully!' });
+      else return res.status(400).json({ message: 'Failed to update email!' });
     } catch (err) {
       if (DEV) console.log(err);
       return res.status(500).json({ error: 'Failed to change email!' });
@@ -46,7 +47,9 @@ module.exports = {
 
       // Check if password is the same as the old before updating
       if (await user.check_password(new_password)) {
-        return res.status(400).json({ error: 'New password is the same as the old!' });
+        return res
+          .status(400)
+          .json({ error: 'New password is the same as the old!' });
       } else {
         // hash new password (mongoose doesn't support pre update hooks)
         const password_hash = await argon2.hash(new_password);
@@ -58,7 +61,9 @@ module.exports = {
           { new: true }
         );
 
-        return res.status(200).json({ message: 'Password was updated successfully!' });
+        return res
+          .status(200)
+          .json({ message: 'Password was updated successfully!' });
       }
     } catch (err) {
       if (DEV) console.log(err);
@@ -85,7 +90,11 @@ module.exports = {
         // user creation was successful, send a jwt_token back
         return res.status(200).json({
           jwt_token: make_token(created_user),
-          user: { id: created_user._id, username: created_user.username, countries: created_user.countries }
+          user: {
+            id: created_user._id,
+            username: created_user.username,
+            countries: created_user.countries
+          }
         });
       } else {
         if (DEV) console.log(err);
@@ -144,7 +153,7 @@ module.exports = {
   login: async (req, res) => {
     try {
       // we only reach here because we are authenticated
-      const { id, username, countries, preferences } = req.user
+      const { id, username, countries, preferences } = req.user;
       const user = {
         id,
         username,
@@ -159,20 +168,18 @@ module.exports = {
   }, // login
 
   update_preferences: async (req, res) => {
-    // req.body.preferences should be an object with properties for each setting
-    //  e.g. { theme: 'light', autoscratch: true }
-    const { username, preferences } = req.body;
-
     try {
-      // Return an error if a username or valid preferences object is not provided
-      if (!username || !preferences) {
+      // req.body.preferences should be an object with properties for each setting
+      //  e.g. { theme: 'light', autoscratch: true }
+      const { preferences } = req.body;
+      if (!preferences) {
         return res
           .status(400)
-          .send({ error: 'You did not provide a username or preferences!' });
+          .send({ error: 'You did not provide updated preferences!' });
       }
 
       const updatedUser = await User.findOneAndUpdate(
-        { username },
+        { username: req.user.username },
         { preferences },
         { new: true }
       );

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -19,16 +19,19 @@ const validate_new_user = ({ username, password, email }) => {
 module.exports = {
   change_email: async (req, res) => {
     try {
-      const { username, new_email } = req.body;
-
-      // update email
-      await User.findOneAndUpdate(
-        { username },
-        { email: new_email },
+      // update email address stored on DB
+      // passport passes on the correct user based on the JWT supplied
+      const response = await User.findOneAndUpdate(
+        { username: req.user.username },
+        { email: req.body.new_email },
         { new: true }
       );
 
-      return res.status(200).json({ message: 'Email was updated successfully!' });
+      console.log(response);
+      if (response)
+        return res.status(200).json({ message: 'Email was updated successfully!' });
+      else
+        return res.status(400).json({ message: 'Failed to update email!' })
     } catch (err) {
       if (DEV) console.log(err);
       return res.status(500).json({ error: 'Failed to change email!' });

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -40,9 +40,9 @@ module.exports = {
 
   change_password: async (req, res) => {
     try {
-      const { username, new_password } = req.body;
+      const { new_password } = req.body;
 
-      const user = await User.findOne({ username });
+      const user = await User.findOne({ username: req.user.username });
 
       // Check if password is the same as the old before updating
       if (await user.check_password(new_password)) {
@@ -53,7 +53,7 @@ module.exports = {
 
         // update password
         await User.findOneAndUpdate(
-          { username },
+          { username: req.user.username },
           { password: password_hash },
           { new: true }
         );


### PR DESCRIPTION
# Description

- Added tests for `change_email` and `change_password`
- Modified `change_email` and `change_password` routes to not require a username in request body. This is because passport already figures out the user based on the JWT token supplied. Front-end code should eventually be cleaned up to reflect this, but the changes to the routes **should** still be functional even without any changes to front end code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- All new and existing tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
