### PR TITLE
Fix #95: Invalid search crashes app

### DIFF
--- a/client/src/Components/CountryPanel/CountryPanel.js
+++ b/client/src/Components/CountryPanel/CountryPanel.js
@@ -12,7 +12,9 @@ const CountryPanel = () => {
     <div className="CountryPanel">
       <AppContextConsumer>
         {value =>
-          value && value.AppState.countryPanelIsOpen ? (
+          value &&
+          value.AppState.countryPanelIsOpen &&
+          value.AppState.currentCountry.info ? (
             <div className="Card ">
               <div className="Card_Header">
                 <span>{value.AppState.currentCountry.info.emoji}</span>


### PR DESCRIPTION
# Description

Add an additional condition before rendering `CountryPanel` to prevent crash if a search result does not match a country name.

Fixes #95 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested manually in browser
- All existing tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
