### PR TITLE
Add country_scratched endpoint/Remove passwords from responses

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -55,6 +55,7 @@ describe('User', () => {
   //need to add tests to add checking for 0 character values
 
   describe('POST routes', () => {
+    /* /api/register */
     describe('/register', () => {
       it('successfully creates new user', async () => {
         const user = {
@@ -67,6 +68,8 @@ describe('User', () => {
           .post('/api/register')
           .send(user);
 
+        expect(response.body.user.password).toBeUndefined();
+        expect(response.body.user.username).toEqual('patrick');
         expect(response.status).toBe(200);
       });
 
@@ -163,6 +166,7 @@ describe('User', () => {
     });
 
     describe('/login', () => {
+      /* /api/login */
       it('successfully logs in a user', async () => {
         const user = { username: 'initialTestUser', password: '123456' };
         const response = await request(server)
@@ -170,6 +174,7 @@ describe('User', () => {
           .send(user);
 
         expect(response.status).toBe(200);
+        expect(response.body.password).toBeUndefined();
         expect(response.body.user).toBeDefined();
         expect(response.body.user.id).toBeDefined();
         expect(response.body.user.username).toBeDefined();
@@ -186,7 +191,9 @@ describe('User', () => {
       });
     });
 
+    /* /api/country_status */
     describe('/country_status', () => {
+      // TODO: Eliminate some duplicate code by making use of beforeEach/afterEach
       const new_country_status = {
         country_code: 'CHN',
         status_code: 1,
@@ -206,6 +213,7 @@ describe('User', () => {
           .set('Authorization', `Bearer ${jwt_token}`)
           .send(new_country_status);
 
+        expect(response.body.password).toBeUndefined();
         expect(response.body.countries.length).toBe(1);
         expect(response.body.countries[0]).toBeDefined();
         expect(response.body.countries[0].country_code).toBe('CHN');
@@ -225,6 +233,7 @@ describe('User', () => {
           .set('Authorization', `Bearer ${jwt_token}`)
           .send(new_country_status);
 
+        expect(response_1.body.password).toBeUndefined();
         expect(response_1.body.countries.length).toBe(1);
         expect(response_1.body.countries[0].country_code).toBe('CHN');
         expect(response_1.body.countries[0].status_code).toBe(1);
@@ -275,6 +284,7 @@ describe('User', () => {
       });
     });
 
+    /* /api/country_notes */
     describe('/country_notes', () => {
       const new_country_status = {
         country_code: 'CHN',
@@ -293,7 +303,7 @@ describe('User', () => {
       it('successfully creates and updates a country that does not exist', async () => {
         const { jwt_token } = initialTestUser.body;
 
-        const updateNote = await request(server)
+        const response = await request(server)
           .post('/api/country_notes')
           .set('Authorization', `Bearer ${jwt_token}`)
           .send({
@@ -302,14 +312,15 @@ describe('User', () => {
             notes: 'New note contents'
           });
 
-        expect(updateNote.status).toBe(201);
-        expect(updateNote.body.countries[1].notes).toEqual('New note contents');
+        expect(response.status).toBe(201);
+        expect(response.body.password).toBeUndefined();
+        expect(response.body.countries[1].notes).toEqual('New note contents');
       });
 
       it('successfully updates an existing country', async () => {
         const { jwt_token } = initialTestUser.body;
 
-        const updateNote = await request(server)
+        const response = await request(server)
           .post('/api/country_notes')
           .set('Authorization', `Bearer ${jwt_token}`)
           .send({
@@ -318,8 +329,9 @@ describe('User', () => {
             notes: 'New note contents'
           });
 
-        expect(updateNote.status).toBe(200);
-        expect(updateNote.body.countries[0].notes).toEqual('New note contents');
+        expect(response.status).toBe(200);
+        expect(response.body.password).toBeUndefined();
+        expect(response.body.countries[0].notes).toEqual('New note contents');
       });
 
       it('fails if no token is provided', async () => {
@@ -355,6 +367,7 @@ describe('User', () => {
       });
     });
 
+    /* /api/country_scratched */
     describe('/country_scratched', () => {
       const new_scratched_status = {
         country_code: 'CHN',
@@ -373,7 +386,7 @@ describe('User', () => {
       it('successfully creates and updates a country that does not exist', async () => {
         const { jwt_token } = initialTestUser.body;
 
-        const updateNote = await request(server)
+        const response = await request(server)
           .post('/api/country_scratched')
           .set('Authorization', `Bearer ${jwt_token}`)
           .send({
@@ -382,14 +395,15 @@ describe('User', () => {
             scratched: true
           });
 
-        expect(updateNote.status).toBe(201);
-        expect(updateNote.body.countries[1].scratched).toBe(true);
+        expect(response.status).toBe(201);
+        expect(response.body.password).toBeUndefined();
+        expect(response.body.countries[1].scratched).toBe(true);
       });
 
       it('successfully creates and updates a new country if it does not exist', async () => {
         const { jwt_token } = initialTestUser.body;
 
-        const updateNote = await request(server)
+        const response = await request(server)
           .post('/api/country_scratched')
           .set('Authorization', `Bearer ${jwt_token}`)
           .send({
@@ -398,8 +412,9 @@ describe('User', () => {
             scratched: true
           });
 
-        expect(updateNote.status).toBe(200);
-        expect(updateNote.body.countries[0].scratched).toBe(true);
+        expect(response.status).toBe(200);
+        expect(response.body.password).toBeUndefined();
+        expect(response.body.countries[0].scratched).toBe(true);
       });
 
       it('fails if no token is provided', async () => {
@@ -456,6 +471,7 @@ describe('User', () => {
 
         expect(newUser).toBeDefined();
         expect(jwt_token).toBeDefined();
+        expect(getUser.body.password).toBeUndefined();
         expect(getUser.body.id).toBe(user.id);
         expect(getUser.body.countries).toBeDefined();
         expect(getUser.body.preferences).toBeDefined();
@@ -524,6 +540,7 @@ describe('User', () => {
           .send(body);
 
         expect(response.status).toBe(200);
+        expect(response.body.password).toBeUndefined();
         expect(response.body.message).toEqual(
           'Email was updated successfully!'
         );
@@ -568,7 +585,8 @@ describe('User', () => {
           .send(body);
 
         expect(response.status).toBe(200);
-        expect(body.new_password).toEqual('654321');
+        expect(response.body.password).toBeUndefined();
+        expect(response.body.message).toEqual('Password was updated successfully!');
       });
 
       it('fails if no token is provided', async () => {
@@ -624,6 +642,7 @@ describe('User', () => {
           .send(updatedPreferences);
 
         expect(response.status).toBe(200);
+        expect(response.body.password).toBeUndefined();
         expect(response.body.username).toBeDefined();
         expect(response.body.preferences.theme).toBe('light');
         expect(response.body.preferences.autoscratch).toBe(false);

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -194,7 +194,7 @@ describe('User', () => {
         username: 'initialTestUser'
       };
 
-      it('successfully adds a new country if it does not exist', async () => {
+      it('successfully creates and updates a country that does not exist', async () => {
         const { jwt_token, user } = initialTestUser.body;
         expect(jwt_token).toBeDefined();
         expect(user.username).toBe('initialTestUser');
@@ -290,7 +290,23 @@ describe('User', () => {
           .send(new_country_status);
       });
 
-      it('successfully updates notes for a country', async () => {
+      it('successfully creates and updates a country that does not exist', async () => {
+        const { jwt_token } = initialTestUser.body;
+
+        const updateNote = await request(server)
+          .post('/api/country_notes')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send({
+            country_code: 'IND',
+            name: 'India',
+            notes: 'New note contents'
+          });
+
+        expect(updateNote.status).toBe(201);
+        expect(updateNote.body.countries[1].notes).toEqual('New note contents');
+      });
+
+      it('successfully updates an existing country', async () => {
         const { jwt_token } = initialTestUser.body;
 
         const updateNote = await request(server)
@@ -319,6 +335,24 @@ describe('User', () => {
 
         expect(updateNote.status).toBe(401);
       });
+
+      it('fails if invalid token is provided', async () => {
+        const jwt_token = initialTestUser.body.jwt_token
+          .split('')
+          .reverse()
+          .join('');
+
+        const updateNote = await request(server)
+          .post('/api/country_notes')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send({
+            country_code: 'CHN',
+            name: 'China',
+            notes: 'This should not get saved'
+          });
+
+        expect(updateNote.status).toBe(401);
+      });
     });
 
     describe('/api/country_scratched', () => {
@@ -336,7 +370,23 @@ describe('User', () => {
           .send(new_scratched_status);
       });
 
-      it('successfully updates scratched status for an existing country', async () => {
+      it('successfully creates and updates a country that does not exist', async () => {
+        const { jwt_token } = initialTestUser.body;
+
+        const updateNote = await request(server)
+          .post('/api/country_scratched')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send({
+            country_code: 'IND',
+            name: 'India',
+            scratched: true
+          });
+
+        expect(updateNote.status).toBe(201);
+        expect(updateNote.body.countries[1].scratched).toBe(true);
+      });
+
+      it('successfully creates and updates a new country if it does not exist', async () => {
         const { jwt_token } = initialTestUser.body;
 
         const updateNote = await request(server)
@@ -350,9 +400,41 @@ describe('User', () => {
 
         expect(updateNote.status).toBe(200);
         expect(updateNote.body.countries[0].scratched).toBe(true);
+      });
 
-      })
-    })
+      it('fails if no token is provided', async () => {
+        const { jwt_token } = initialTestUser.body;
+
+        const updateNote = await request(server)
+          .post('/api/country_notes')
+          .send({
+            country_code: 'CHN',
+            name: 'China',
+            scratched: true
+          });
+
+        expect(updateNote.status).toBe(401);
+      });
+
+      it('fails if invalid token is provided', async () => {
+        const jwt_token = initialTestUser.body.jwt_token
+          .split('')
+          .reverse()
+          .join('');
+
+
+        const updateNote = await request(server)
+          .post('/api/country_notes')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send({
+            country_code: 'CHN',
+            name: 'China',
+            scratched: true
+          });
+
+        expect(updateNote.status).toBe(401);
+      });
+    });
   });
 
   describe('GET routes', () => {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -275,7 +275,7 @@ describe('User', () => {
       });
     });
 
-    describe('/api/country_notes', () => {
+    describe('/country_notes', () => {
       const new_country_status = {
         country_code: 'CHN',
         status_code: 1,
@@ -355,7 +355,7 @@ describe('User', () => {
       });
     });
 
-    describe('/api/country_scratched', () => {
+    describe('/country_scratched', () => {
       const new_scratched_status = {
         country_code: 'CHN',
         status_code: 0,
@@ -456,7 +456,7 @@ describe('User', () => {
 
         expect(newUser).toBeDefined();
         expect(jwt_token).toBeDefined();
-        expect(getUser.body._id).toBe(user.id);
+        expect(getUser.body.id).toBe(user.id);
         expect(getUser.body.countries).toBeDefined();
         expect(getUser.body.preferences).toBeDefined();
         expect(getUser.body.username).toBe('getuser1');

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -320,6 +320,39 @@ describe('User', () => {
         expect(updateNote.status).toBe(401);
       });
     });
+
+    describe('/api/country_scratched', () => {
+      const new_scratched_status = {
+        country_code: 'CHN',
+        status_code: 0,
+        name: 'China'
+      };
+
+      beforeEach(async () => {
+        const { jwt_token } = initialTestUser.body;
+        const response = await request(server)
+          .post('/api/country_status')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send(new_scratched_status);
+      });
+
+      it('successfully updates scratched status for an existing country', async () => {
+        const { jwt_token } = initialTestUser.body;
+
+        const updateNote = await request(server)
+          .post('/api/country_scratched')
+          .set('Authorization', `Bearer ${jwt_token}`)
+          .send({
+            country_code: 'CHN',
+            name: 'China',
+            scratched: true
+          });
+
+        expect(updateNote.status).toBe(200);
+        expect(updateNote.body.countries[0].scratched).toBe(true);
+
+      })
+    })
   });
 
   describe('GET routes', () => {

--- a/api/controllers/statusController.js
+++ b/api/controllers/statusController.js
@@ -11,6 +11,8 @@ Expects a json object with the following structure:
   }
 */
 
+// TODO: A lot of duplicate code written in these functions. Refactor to eliminate some repition.
+
 module.exports = {
   handle_status: async (req, res) => {
     const { country_code, status_code, name } = req.body;
@@ -133,7 +135,12 @@ module.exports = {
             options
           );
 
-          return res.status(200).json(updatedUser);
+          const response = {
+            username: updatedUser.username,
+            countries: updatedUser.countries,
+          }
+
+          return res.status(200).json(response);
         } catch (err) {
           if (DEV) console.log(err);
           return res
@@ -149,7 +156,13 @@ module.exports = {
             createCountryQuery,
             options
           );
-          return res.status(201).json(updatedUser);
+
+          const response = {
+            username: updatedUser.username,
+            countries: updatedUser.countries,
+          }
+
+          return res.status(201).json(response);
         } catch (err) {
           return res
             .status(409)
@@ -195,7 +208,12 @@ module.exports = {
             options
           );
 
-          return res.status(200).json(updatedUser);
+          const response = {
+            username: updatedUser.username,
+            countries: updatedUser.countries,
+          }
+
+          return res.status(200).json(response);
         } catch (err) {
           if (DEV) console.log(err);
           return res
@@ -212,7 +230,13 @@ module.exports = {
             createCountryQuery,
             options
           );
-          return res.status(201).json(updatedUser);
+
+          const response = {
+            username: updatedUser.username,
+            countries: updatedUser.countries,
+          }
+
+          return res.status(201).json(response);
         } catch (err) {
           return res
             .status(409)

--- a/api/controllers/statusController.js
+++ b/api/controllers/statusController.js
@@ -52,12 +52,18 @@ module.exports = {
       // If country is found on user, update the country's code with the status_code in req.body
       if (findCountryOnUser) {
         try {
-          const newDoc = await User.findOneAndUpdate(
+          const updatedUser = await User.findOneAndUpdate(
             findUserCountryConditions,
             editCountryQuery,
             options
           );
-          return res.status(200).json(newDoc);
+
+          const response = {
+            username: updatedUser.username,
+            countries: updatedUser.countries,
+          }
+
+          return res.status(200).json(response);
         } catch (err) {
           if (DEV) console.log(err);
           return res

--- a/api/controllers/statusController.js
+++ b/api/controllers/statusController.js
@@ -75,12 +75,18 @@ module.exports = {
       // If country does not exist on user, create a new object with the status_code in req.body
       else {
         try {
-          const newDoc = await User.findOneAndUpdate(
+          const updatedUser = await User.findOneAndUpdate(
             { username },
             createCountryQuery,
             options
           );
-          return res.status(201).json(newDoc);
+
+          const response = {
+            username: updatedUser.username,
+            countries: updatedUser.countries,
+          }
+
+          return res.status(201).json(response);
         } catch (err) {
           if (DEV) console.log(err);
           return res

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -20,19 +20,16 @@ module.exports = {
   change_email: async (req, res) => {
     try {
       // update email address stored on DB
-      // passport passes on the correct user based on the JWT supplied
+      // passport passes on req.user based on the JWT supplied
       const response = await User.findOneAndUpdate(
         { username: req.user.username },
         { email: req.body.new_email },
         { new: true }
       );
 
-      console.log(response);
-      if (response)
-        return res
-          .status(200)
-          .json({ message: 'Email was updated successfully!' });
-      else return res.status(400).json({ message: 'Failed to update email!' });
+      return response.email === req.body.new_email.toLowerCase()
+        ? res.status(200).json({ message: 'Email was updated successfully!' })
+        : res.status(400).json({ message: 'Failed to update email!' });
     } catch (err) {
       if (DEV) console.log(err);
       return res.status(500).json({ error: 'Failed to change email!' });
@@ -194,7 +191,7 @@ module.exports = {
         username: updatedUser.username,
         preferences: updatedUser.preferences,
         countries: updatedUser.countries
-      }
+      };
 
       return res.status(200).json(response);
     } catch (err) {

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -127,9 +127,15 @@ module.exports = {
     try {
       const id = req.params.id;
       if (!id) res.status(400).json({ error: 'ID is a required parameter' });
-      const foundUser = await User.findById(id);
-      const user = { id: req.user._id, username: req.user.username }; // add the things you need to send
-      return res.status(200).json(foundUser);
+      // const foundUser = await User.findById(id);
+      const user = {
+        id: req.user._id,
+        username: req.user.username,
+        email: req.user.email,
+        countries: req.user.countries,
+        preferences: req.user.preferences
+      }; // add the things you need to send
+      return res.status(200).json(user);
     } catch (err) {
       if (DEV) console.log(err);
       return res.status(500).json({ error: 'Failed to get user!' });

--- a/api/controllers/user_controller.js
+++ b/api/controllers/user_controller.js
@@ -190,7 +190,13 @@ module.exports = {
         { new: true }
       );
 
-      return res.status(200).json(updatedUser);
+      const response = {
+        username: updatedUser.username,
+        preferences: updatedUser.preferences,
+        countries: updatedUser.countries
+      }
+
+      return res.status(200).json(response);
     } catch (err) {
       if (DEV) console.log(err);
       return res.status(500).send({ error: 'Failed to update preferences' });

--- a/api/routes.js
+++ b/api/routes.js
@@ -12,7 +12,8 @@ const {
 //below handles the status change of country
 const {
   handle_status,
-  handle_notes
+  handle_notes,
+  handle_scratched
 } = require('./controllers/statusController');
 
 const passport = require('./utils/passport');
@@ -60,6 +61,7 @@ module.exports = server => {
   // Update country on User routes
   server.route('/api/country_status').post(protected_route, handle_status);
   server.route('/api/country_notes').post(protected_route, handle_notes);
+  server.route('/api/country_scratched').post(protected_route, handle_scratched);
 
   // Update User settings routes
   server.route('/api/change_password').put(protected_route, change_password);

--- a/client/src/Components/Settings/ChangeEmail.js
+++ b/client/src/Components/Settings/ChangeEmail.js
@@ -21,18 +21,11 @@ class ChangeEmail extends Component {
   // handleSubmit for ChangeEmail
   handleSubmit = async e => {
     e.preventDefault();
-    // TODO: Error handling
-    const { currentPassword, newEmail } = this.state;
+    const { newEmail } = this.state;
 
-    if (!currentPassword || !newEmail) {
+    if (!newEmail) {
       return this.setState({
         emailError: 'Please complete the form'
-      });
-    }
-
-    if (currentPassword.length < 6) {
-      return this.setState({
-        emailError: 'Invalid Password'
       });
     }
 
@@ -40,8 +33,6 @@ class ChangeEmail extends Component {
       const token = localStorage.getItem('token');
 
       const body = {
-        username: this.props.user.username,
-        password: currentPassword,
         new_email: newEmail
       };
 
@@ -88,16 +79,16 @@ class ChangeEmail extends Component {
               />
             </div>
 
-            <div className="ChangeEmail__currentPassword">
-              <h5>Current Password</h5>
-              <input
-                type="password"
-                name="currentPassword"
-                placeholder="Current Password"
-                value={this.state.currentPassword}
-                onChange={e => this.handleChange(e)}
-              />
-            </div>
+            {/* <div className="ChangeEmail__currentPassword"> */}
+            {/*   <h5>Current Password</h5> */}
+            {/*   <input */}
+            {/*     type="password" */}
+            {/*     name="currentPassword" */}
+            {/*     placeholder="Current Password" */}
+            {/*     value={this.state.currentPassword} */}
+            {/*     onChange={e => this.handleChange(e)} */}
+            {/*   /> */}
+            {/* </div> */}
 
             <input
               className="ChangeEmail__submit"


### PR DESCRIPTION
# Description

- Adds an endpoint at `/api/country_scratched` to updated the scratched status of a country
- Remove passwords from all API responses
- Add more tests
- Update and improve existing tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Added new automated tests in `server.test.js`
- All new and existing tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
