### PR TITLE
Prevent ChangeEmail/ChangePassword from both being open

### DIFF
--- a/client/src/AppContext.js
+++ b/client/src/AppContext.js
@@ -16,8 +16,6 @@ const AppContext = React.createContext();
 export class AppContextProvider extends Component {
   state = {
     authenticated: false,
-    user: {},
-    userPosition: { lat: 22.28552, lng: 114.15769 },
     currentCountry: {
       code: '',
       info: {},
@@ -26,13 +24,15 @@ export class AppContextProvider extends Component {
       notes: '',
       editNoteMode: false
     },
+    currentCountryStatus: null,
     failedLogin: false,
     failedSignUp: false,
-    currentCountryStatus: null,
+    failedSignUpMessage: '',
     searchCountry: '',
     showingSettings: false,
     showingCountryPanel: false,
-    failedSignUpMessage: ''
+    user: {},
+    userPosition: { lat: 22.28552, lng: 114.15769 }
   };
 
   async componentDidMount() {
@@ -251,7 +251,10 @@ export class AppContextProvider extends Component {
 
   // Update state with currently selected country, called in Map.js
   updateCurrentCountry = async (code, info) => {
-    if (!code) return this.closeCountryPanel();
+    if (!code) {
+      this.setState({ currentCountryStatus: null, currentCountry: {} });
+      return this.closeCountryPanel();
+    }
 
     const geoInfo = getCountryShapeFromCode(code);
     const scratched = this.isScratched(code);

--- a/client/src/AppContext.js
+++ b/client/src/AppContext.js
@@ -1,6 +1,11 @@
 import React, { Component } from 'react';
 import axios from 'axios';
-import { clearLocalstorage, getCountryShapeFromCode } from './utils.js';
+import world from 'country-data';
+import {
+  clearLocalstorage,
+  getCountryShapeFromCode,
+  getCountryCodeFromName
+} from './utils.js';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 
@@ -24,6 +29,7 @@ export class AppContextProvider extends Component {
     failedLogin: false,
     failedSignUp: false,
     currentCountryStatus: null,
+    searchCountry: '',
     showingSettings: false,
     showingCountryPanel: false,
     failedSignUpMessage: ''
@@ -247,7 +253,7 @@ export class AppContextProvider extends Component {
   }; // handleSliderMove
 
   // Update state with currently selected country, called in Map.js
-  handleUpdateCurrentCountry = (code, info) => {
+  updateCurrentCountry = async (code, info) => {
     if (!code) return this.closeCountryPanel();
 
     const geoInfo = getCountryShapeFromCode(code);
@@ -263,13 +269,20 @@ export class AppContextProvider extends Component {
       notes,
       editNoteMode: false
     };
-    this.setState({
+    await this.setState({
       currentCountry,
       showingCountryPanel: true
     });
-    this.setState({
+    await this.setState({
       currentCountryStatus: this.getCurrentCountryStatus()
     });
+  };
+
+  handleSearchSubmit = e => {
+    e.preventDefault();
+    const countryCode = getCountryCodeFromName(e.target.search.value);
+    const countryInfo = world.countries[countryCode];
+    this.updateCurrentCountry(countryCode, countryInfo);
   };
 
   handleUpdateNotes = async () => {
@@ -407,18 +420,19 @@ export class AppContextProvider extends Component {
           closeCountryPanel: this.closeCountryPanel,
           currentCountryInfo: this.state.currentCountry.geoInfo,
           handleChangeNote: this.handleChangeNote,
+          handleScratched: this.handleScratched,
+          handleSearchSubmit: this.handleSearchSubmit,
           handleSignIn: this.handleSignIn,
           handleSignOut: this.handleSignOut,
           handleSignUp: this.handleSignUp,
           handleSliderMove: this.handleSliderMove,
-          handleScratched: this.handleScratched,
           handleUpdateNotes: this.handleUpdateNotes,
           handleUpdatePreferences: this.handleUpdatePreferences,
-          turnOnEditNote: this.turnOnEditNote,
           resetAppStateError: this.resetAppStateError,
-          updateCurrentCountry: this.handleUpdateCurrentCountry,
-          updateUserPosition: this.handleUpdateUserPosition,
-          toggleSettings: this.toggleSettings
+          toggleSettings: this.toggleSettings,
+          turnOnEditNote: this.turnOnEditNote,
+          updateCurrentCountry: this.updateCurrentCountry,
+          updateUserPosition: this.handleUpdateUserPosition
         }}
       >
         {this.props.children}

--- a/client/src/AppContext.js
+++ b/client/src/AppContext.js
@@ -24,6 +24,7 @@ export class AppContextProvider extends Component {
     failedLogin: false,
     failedSignUp: false,
     currentCountryStatus: null,
+    showingSettings: false,
     countryPanelIsOpen: false,
     failedSignUpMessage: ''
   };
@@ -68,6 +69,10 @@ export class AppContextProvider extends Component {
       this.getLocationUsingIP(); // geo location not available on device
     }
   } // componentDidMount
+
+  toggleSettings = () => {
+    this.setState({ showingSettings: !this.state.showingSettings });
+  };
 
   closeCountryPanel = () => {
     this.setState({
@@ -424,7 +429,8 @@ export class AppContextProvider extends Component {
           turnOnEditNote: this.turnOnEditNote,
           resetAppStateError: this.resetAppStateError,
           updateCurrentCountry: this.handleUpdateCurrentCountry,
-          updateUserPosition: this.handleUpdateUserPosition
+          updateUserPosition: this.handleUpdateUserPosition,
+          toggleSettings: this.toggleSettings
         }}
       >
         {this.props.children}

--- a/client/src/AppContext.js
+++ b/client/src/AppContext.js
@@ -25,7 +25,7 @@ export class AppContextProvider extends Component {
     failedSignUp: false,
     currentCountryStatus: null,
     showingSettings: false,
-    countryPanelIsOpen: false,
+    showingCountryPanel: false,
     failedSignUpMessage: ''
   };
 
@@ -46,16 +46,11 @@ export class AppContextProvider extends Component {
           requestOptions
         );
 
-        if (response.status === 200) {
+        if (response.status === 200)
           this.setState({
             authenticated: true,
             user: { ...response.data }
           });
-        } else {
-          clearLocalstorage(); // response was not 200
-        }
-      } else {
-        clearLocalstorage(); // token or user not in localstorage
       }
     } catch (e) {
       // failed async
@@ -76,7 +71,7 @@ export class AppContextProvider extends Component {
 
   closeCountryPanel = () => {
     this.setState({
-      countryPanelIsOpen: false
+      showingCountryPanel: false
     });
   }; // closeCountryPanel
 
@@ -128,7 +123,7 @@ export class AppContextProvider extends Component {
   };
 
   handleChangeNote = e => {
-    console.log(e.target.name, e.target.value)
+    console.log(e.target.name, e.target.value);
     const currentCountry = { ...this.state.currentCountry };
     currentCountry[e.target.name] = e.target.value;
     this.setState({ currentCountry });
@@ -141,7 +136,7 @@ export class AppContextProvider extends Component {
       const body = {
         country_code: currentCountry.code,
         name: currentCountry.info.name,
-        scratched: true,
+        scratched: true
         // notes: currentCountry.notes
       };
 
@@ -156,7 +151,7 @@ export class AppContextProvider extends Component {
       );
 
       currentCountry.scratched = true;
-      console.log(response.data)
+      console.log(response.data);
       this.setState({
         currentCountry,
         currentCountryStatus: 0,
@@ -253,9 +248,7 @@ export class AppContextProvider extends Component {
 
   // Update state with currently selected country, called in Map.js
   handleUpdateCurrentCountry = (code, info) => {
-    console.log(code);
-    if (!code)
-      return this.closeCountryPanel();
+    if (!code) return this.closeCountryPanel();
 
     const geoInfo = getCountryShapeFromCode(code);
     const scratched = this.isScratched(code);
@@ -272,7 +265,7 @@ export class AppContextProvider extends Component {
     };
     this.setState({
       currentCountry,
-      countryPanelIsOpen: true
+      showingCountryPanel: true
     });
     this.setState({
       currentCountryStatus: this.getCurrentCountryStatus()
@@ -294,7 +287,11 @@ export class AppContextProvider extends Component {
         headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
       };
 
-      const response = await axios.post(`${BACKEND_URL}/country_notes`, body, options);
+      const response = await axios.post(
+        `${BACKEND_URL}/country_notes`,
+        body,
+        options
+      );
 
       currentCountry.editNoteMode = false;
       this.setState({
@@ -321,20 +318,11 @@ export class AppContextProvider extends Component {
         options
       );
       if (response.status === 200) {
-        console.log(
-          'Preferences were updated successfully!',
-          response.status,
-          response.data
-        );
         this.setState({ user: response.data });
       }
 
       if (response.status === 400)
-        console.log(
-          'Preferences failed to update!',
-          response.status,
-          response.body
-        );
+        console.error('Preferences failed to update!');
     } catch (err) {
       console.error('There was an error trying to update preferences!');
     }

--- a/client/src/Components/CountryBorder/CountryBorder.js
+++ b/client/src/Components/CountryBorder/CountryBorder.js
@@ -118,11 +118,12 @@ export default class CountryBorder extends Component {
   }
 
   drawBorder = () => {
-    // Get the correct fill color based on status. Need to check if
-    // this.props.currentCountryStatus exists to prevent any crashes
+    // Get the correct fill color based on status.
+    // Check if this.props.currentCountryStatus exists to prevent any crashes
     const color = this.props.currentCountryStatus
       ? colorPalette[this.props.currentCountryStatus]
       : 'black';
+    // TODO: Fix deprecation warning
     const canvas = this.refs.canvas;
     const context = canvas.getContext('2d');
     if (context) context.clearRect(0, 0, canvasWidth, canvasHeight);

--- a/client/src/Components/CountryBorder/CountryBorder.js
+++ b/client/src/Components/CountryBorder/CountryBorder.js
@@ -45,7 +45,6 @@ const draw = (context, canvasWidth, canvasHeight, bounds, geometry, color) => {
       });
     context.closePath();
     context.fill();
-    // context.stroke();
   }
   // Handles countries made up of multiple unconnected polygons
   else if (geometry.type === 'MultiPolygon') {
@@ -68,7 +67,6 @@ const draw = (context, canvasWidth, canvasHeight, bounds, geometry, color) => {
         });
       context.closePath();
       context.fill();
-      // context.stroke();
     });
   }
 };
@@ -78,31 +76,41 @@ export default class CountryBorder extends Component {
     marks: {
       0: {
         style: {
-          color: 'gray'
+          color: 'gray',
+          fontWeight: 'bold',
+          textShadow: '1px 0px 0px black'
         },
         label: 'None'
       },
       1: {
         style: {
-          color: colorPalette[1]
+          color: 'purple',
+          fontWeight: 'bold',
+          textShadow: '1px 0px 0px black'
         },
         label: 'Wishlist'
       },
       2: {
         style: {
-          color: colorPalette[2]
+          color: colorPalette[2],
+          fontWeight: 'bold',
+          textShadow: '1px 0px 0px black'
         },
         label: 'Transited'
       },
       3: {
         style: {
-          color: colorPalette[3]
+          color: colorPalette[3],
+          fontWeight: 'bold',
+          textShadow: '1px 0px 0px black'
         },
         label: 'Visited'
       },
       4: {
         style: {
-          color: colorPalette[4]
+          color: colorPalette[4],
+          fontWeight: 'bold',
+          textShadow: '1px 0px 0px black'
         },
         label: 'Lived'
       }
@@ -123,8 +131,7 @@ export default class CountryBorder extends Component {
     const color = this.props.currentCountryStatus
       ? colorPalette[this.props.currentCountryStatus]
       : 'black';
-    // TODO: Fix deprecation warning
-    const canvas = this.refs.canvas;
+    const canvas = this.refs.canvas; // TODO: Fix deprecation warning
     const context = canvas.getContext('2d');
     if (context) context.clearRect(0, 0, canvasWidth, canvasHeight);
     // only draw if we have the geometry
@@ -166,19 +173,21 @@ export default class CountryBorder extends Component {
             />
           </ScratchCard>
         )}
-        <div className="CountryBorder__SliderContainer">
-          <Slider
-            className="Slider"
-            min={0}
-            max={4}
-            marks={this.state.marks}
-            step={null}
-            onChange={this.props.handleSliderMove}
-            defaultValue={0}
-            value={this.props.currentCountryStatus}
-            disabled={!this.props.scratched}
-          />
-        </div>
+        {this.props.scratched && (
+          <div className="CountryBorder__SliderContainer">
+            <Slider
+              className="Slider"
+              min={0}
+              max={4}
+              marks={this.state.marks}
+              step={null}
+              onChange={this.props.handleSliderMove}
+              defaultValue={0}
+              value={this.props.currentCountryStatus}
+              disabled={!this.props.scratched}
+            />
+          </div>
+        )}
       </div>
     );
   }

--- a/client/src/Components/CountryPanel/CountryPanel.js
+++ b/client/src/Components/CountryPanel/CountryPanel.js
@@ -23,7 +23,7 @@ const CountryPanel = () => {
               color: themeColors.color[currentTheme]
             }}
             className={
-              value.AppState.countryPanelIsOpen
+              value.AppState.showingCountryPanel
                 ? 'CountryPanel CountryPanel-open'
                 : 'CountryPanel CountryPanel-closed'
             }

--- a/client/src/Components/CountryPanel/CountryPanel.js
+++ b/client/src/Components/CountryPanel/CountryPanel.js
@@ -20,7 +20,8 @@ const CountryPanel = () => {
           <div
             style={{
               backgroundColor: themeColors.background[currentTheme],
-              color: themeColors.color[currentTheme]
+              color: themeColors.color[currentTheme],
+              border: `1px solid ${themeColors.borderColor[currentTheme]}`
             }}
             className={
               value.AppState.showingCountryPanel

--- a/client/src/Components/Dashboard/Dashboard.js
+++ b/client/src/Components/Dashboard/Dashboard.js
@@ -12,18 +12,11 @@ import './Dashboard.css';
 
 class Dashboard extends Component {
   state = {
-    showingSettings: false,
-    searchCountry: ''
+    showingSettings: false
   };
 
   toggleSettings = () => {
     this.setState({ showingSettings: !this.state.showingSettings });
-  };
-
-  handleSearchSubmit = e => {
-    e.preventDefault();
-    const searchQuery = e.target.search.value;
-    this.setState({ searchCountry: searchQuery });
   };
 
   render() {
@@ -42,7 +35,7 @@ class Dashboard extends Component {
                 <Legend />
                 <SearchCountry
                   updateCurrentCountry={value.updateCurrentCountry}
-                  handleSearchSubmit={this.handleSearchSubmit}
+                  handleSearchSubmit={value.handleSearchSubmit}
                   theme={currentTheme}
                 />
                 <Map

--- a/client/src/Components/Dashboard/Dashboard.js
+++ b/client/src/Components/Dashboard/Dashboard.js
@@ -29,9 +29,6 @@ class Dashboard extends Component {
   render() {
     return (
       <div className="Dashboard">
-        <Nav toggleSettings={this.toggleSettings} />
-        <CountryPanel />
-        <Legend />
         <AppContextConsumer>
           {value => {
             const currentTheme =
@@ -39,34 +36,29 @@ class Dashboard extends Component {
                 ? value.AppState.user.preferences.theme
                 : 'standard';
             return (
-              <SearchCountry
-                updateCurrentCountry={value.updateCurrentCountry}
-                handleSearchSubmit={this.handleSearchSubmit}
-                theme={currentTheme}
-              />
+              <React.Fragment>
+                <Nav toggleSettings={value.toggleSettings} />
+                <CountryPanel />
+                <Legend />
+                <SearchCountry
+                  updateCurrentCountry={value.updateCurrentCountry}
+                  handleSearchSubmit={this.handleSearchSubmit}
+                  theme={currentTheme}
+                />
+                <Map
+                  userPosition={value.AppState.userPosition}
+                  updateUserPosition={value.updateUserPosition}
+                  searchCountry={this.state.searchCountry}
+                  updateCurrentCountry={value.updateCurrentCountry}
+                  currentCountry={value.AppState.currentCountry}
+                  user={value.AppState.user}
+                  scratched={value.AppState.scratched}
+                />
+                <Settings showingSettings={value.AppState.showingSettings} />
+              </React.Fragment>
             );
           }}
         </AppContextConsumer>
-        <AppContextConsumer>
-          {value => {
-            return (
-              <Map
-                userPosition={value.AppState.userPosition}
-                updateUserPosition={value.updateUserPosition}
-                searchCountry={this.state.searchCountry}
-                updateCurrentCountry={value.updateCurrentCountry}
-                currentCountry={value.AppState.currentCountry}
-                user={value.AppState.user}
-                scratched={value.AppState.scratched}
-              />
-            );
-          }}
-        </AppContextConsumer>
-
-        <Settings
-          onClick={this.toggleSettings}
-          showingSettings={this.state.showingSettings}
-        />
       </div>
     );
   }

--- a/client/src/Components/Legend/Legend.js
+++ b/client/src/Components/Legend/Legend.js
@@ -17,8 +17,8 @@ const Legend = () => {
             className="Legend"
             style={{
               backgroundColor: themeColors.background[currentTheme],
-              color: themeColors.color[currentTheme],
-              border: `1px solid ${themeColors.color[currentTheme]}`
+              color: themeColors.fontColor[currentTheme],
+              border: `1px solid ${themeColors.borderColor[currentTheme]}`
             }}
           >
             <div className="Legend__Wishlist">

--- a/client/src/Components/Legend/Legend.js
+++ b/client/src/Components/Legend/Legend.js
@@ -17,7 +17,8 @@ const Legend = () => {
             className="Legend"
             style={{
               backgroundColor: themeColors.background[currentTheme],
-              color: themeColors.color[currentTheme]
+              color: themeColors.color[currentTheme],
+              border: `1px solid ${themeColors.color[currentTheme]}`
             }}
           >
             <div className="Legend__Wishlist">

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -23,8 +23,8 @@ const Nav = props => {
             className="Nav"
             style={{
               backgroundColor: themeColors.background[currentTheme],
-              color: themeColors.color[currentTheme],
-              border: `1px solid ${themeColors.color[currentTheme]}`
+              color: themeColors.fontColor[currentTheme],
+              border: `1px solid ${themeColors.borderColor[currentTheme]}`
             }}
           >
             <h1 className="Nav__title">MapScratcher</h1>

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -23,7 +23,8 @@ const Nav = props => {
             className="Nav"
             style={{
               backgroundColor: themeColors.background[currentTheme],
-              color: themeColors.color[currentTheme]
+              color: themeColors.color[currentTheme],
+              border: `1px solid ${themeColors.color[currentTheme]}`
             }}
           >
             <h1 className="Nav__title">MapScratcher</h1>

--- a/client/src/Components/Note/Note.js
+++ b/client/src/Components/Note/Note.js
@@ -5,6 +5,7 @@ import './Note.css';
 
 const Note = props => {
   let display;
+  // If a note is being edited, display input field
   if (props.country.editNoteMode) {
     display = (
       <div className="Notes__EditMode">
@@ -20,31 +21,33 @@ const Note = props => {
         />
       </div>
     );
-  } else {
-    if (props.country.notes) {
-      display = (
-        <div className="Notes__ViewMode">
-          <FontAwesomeIcon
-            className="ViewMode__edit"
-            onClick={props.turnOnEditNote}
-            icon="edit"
-          />
-          <div className="ViewMode__Notes">{props.country.notes}</div>
-        </div>
-      );
-    } else {
-      display = (
-        <div className="Notes__ViewMode">
-          <FontAwesomeIcon
-            className="ViewMode__add"
-            onClick={props.turnOnEditNote}
-            icon="plus-circle"
-          />
-          <span>Add a note</span>
-        </div>
-      );
-    }
+  } 
+  // If a note is not being edited show the note or 'Add a note'
+  else {
+    display = props.country.notes ? (
+      // If a note already exists, display it
+      <div className="Notes__ViewMode">
+        <FontAwesomeIcon
+          className="ViewMode__edit"
+          onClick={props.turnOnEditNote}
+          icon="edit"
+        />
+        <div className="ViewMode__Notes">{props.country.notes}</div>
+      </div>
+    ) : (
+      // If a note doesn't exist, show 'Add a note'
+      <div className="Notes__ViewMode">
+        <FontAwesomeIcon
+          className="ViewMode__add"
+          onClick={props.turnOnEditNote}
+          icon="plus-circle"
+        />
+        <span>Add a note</span>
+      </div>
+    );
   }
+
   return <div className="Note">{display}</div>;
 };
+
 export default Note;

--- a/client/src/Components/SearchCountry/SearchCountry.css
+++ b/client/src/Components/SearchCountry/SearchCountry.css
@@ -5,11 +5,10 @@
   z-index: 11;
   height: auto;
   width: auto;
-  padding: 20px;
   font-family: Roboto, sans-serif;
 }
 .SearchCountry .SearchCountry__input {
-  padding: 20px;
-  height: 50px;
+  padding: 10px 20px;
+  height: 30px;
   box-shadow: -3px 3px 2px 2px rgba(0, 0, 0, 0.2);
 }

--- a/client/src/Components/SearchCountry/SearchCountry.js
+++ b/client/src/Components/SearchCountry/SearchCountry.js
@@ -27,7 +27,7 @@ class SearchCountry extends Component {
       <form className="SearchCountry" onSubmit={this.handleSearchSubmit}>
         <input
           className="SearchCountry__input"
-          type="search"
+          type="text"
           name="search"
           value={this.formValue}
           placeholder="Search Countries..."

--- a/client/src/Components/SearchCountry/SearchCountry.js
+++ b/client/src/Components/SearchCountry/SearchCountry.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
-import world from 'country-data';
-import { getCountryCodeFromName } from '../../utils.js';
 
-import './SearchCountry.css';
 import themeColors from '../themeColors.js';
+import './SearchCountry.css';
 
 class SearchCountry extends Component {
   state = {
@@ -15,16 +13,9 @@ class SearchCountry extends Component {
     this.setState({ formValue: e.target.value });
   };
 
-  handleSearchSubmit = e => {
-    e.preventDefault();
-    const countryCode = getCountryCodeFromName(e.target.search.value);
-    const countryInfo = world.countries[countryCode];
-    this.props.updateCurrentCountry(countryCode, countryInfo);
-  };
-
   render() {
     return (
-      <form className="SearchCountry" onSubmit={this.handleSearchSubmit}>
+      <form className="SearchCountry" onSubmit={this.props.handleSearchSubmit}>
         <input
           className="SearchCountry__input"
           type="text"

--- a/client/src/Components/SearchCountry/SearchCountry.js
+++ b/client/src/Components/SearchCountry/SearchCountry.js
@@ -25,8 +25,8 @@ class SearchCountry extends Component {
           onChange={e => this.handleSearchChange(e)}
           style={{
             backgroundColor: themeColors.background[this.props.theme],
-            color: themeColors.color[this.props.theme],
-            border: `1px solid ${themeColors.color[this.props.theme]}`
+            color: themeColors.fontColor[this.props.theme],
+            border: `1px solid ${themeColors.borderColor[this.props.theme]}`
           }}
         />
       </form>

--- a/client/src/Components/SearchCountry/SearchCountry.js
+++ b/client/src/Components/SearchCountry/SearchCountry.js
@@ -25,7 +25,8 @@ class SearchCountry extends Component {
           onChange={e => this.handleSearchChange(e)}
           style={{
             backgroundColor: themeColors.background[this.props.theme],
-            color: themeColors.color[this.props.theme]
+            color: themeColors.color[this.props.theme],
+            border: `1px solid ${themeColors.color[this.props.theme]}`
           }}
         />
       </form>

--- a/client/src/Components/SearchCountry/SearchCountry.less
+++ b/client/src/Components/SearchCountry/SearchCountry.less
@@ -5,15 +5,12 @@
   z-index: 11;
   height: auto;
   width: auto;
-  padding: 20px;
+  // padding: 20px;
   font-family: Roboto, sans-serif;
 
   .SearchCountry__input {
-    padding: 20px;
-    height: 50px;
+    padding: 10px 20px;
+    height: 30px;
     box-shadow: -3px 3px 2px 2px rgba(0, 0, 0, 0.2);
   }
-  // ::placeholder {
-  //   color: white;
-  // }
 }

--- a/client/src/Components/Settings/ChangeEmail.css
+++ b/client/src/Components/Settings/ChangeEmail.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
-  margin: 20px;
+  margin: 15px;
 }
 .ChangeEmail h1 {
   cursor: pointer;
@@ -22,6 +22,9 @@
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
+}
+.ChangeEmail .Settings__ChangeEmail #NewEmail__header {
+  padding-bottom: 5px;
 }
 .ChangeEmail .Settings__ChangeEmail .ChangeEmail__submit {
   width: 100px;

--- a/client/src/Components/Settings/ChangeEmail.js
+++ b/client/src/Components/Settings/ChangeEmail.js
@@ -8,14 +8,9 @@ const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 
 class ChangeEmail extends Component {
   state = {
-    show: false,
     currentPassword: '',
     newEmail: '',
     emailError: ''
-  };
-
-  toggleShow = () => {
-    this.setState({ show: !this.state.show });
   };
 
   // handleSubmit for ChangeEmail
@@ -65,8 +60,10 @@ class ChangeEmail extends Component {
   render() {
     return (
       <div className="ChangeEmail">
-        <h1 onClick={() => this.toggleShow()}>Change Email...</h1>
-        {this.state.show && (
+        <h1 onClick={() => this.props.handleChangeEmailClick()}>
+          Change Email...
+        </h1>
+        {this.props.showingChangeEmail && (
           <form onSubmit={this.handleSubmit} className="Settings__ChangeEmail">
             <div className="ChangeEmail__newEmail">
               <h5>New Email</h5>

--- a/client/src/Components/Settings/ChangeEmail.js
+++ b/client/src/Components/Settings/ChangeEmail.js
@@ -65,12 +65,12 @@ class ChangeEmail extends Component {
         </h1>
         {this.props.showingChangeEmail && (
           <form onSubmit={this.handleSubmit} className="Settings__ChangeEmail">
-            <div className="ChangeEmail__newEmail">
-              <h5>New Email</h5>
+            <div className="ChangeEmail__NewEmail">
+              <h5 id="NewEmail__header">New Email</h5>
               <input
                 type="text"
                 name="newEmail"
-                placeholder="New Email"
+                // placeholder="New Email"
                 value={this.state.newEmail}
                 onChange={e => this.handleChange(e)}
               />

--- a/client/src/Components/Settings/ChangeEmail.less
+++ b/client/src/Components/Settings/ChangeEmail.less
@@ -2,7 +2,7 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
-  margin: 20px;
+  margin: 15px;
   h1 {
     cursor: pointer;
     &:hover {
@@ -23,6 +23,9 @@
       justify-content: center;
     }
 
+    #NewEmail__header {
+      padding-bottom: 5px;
+    }
     .ChangeEmail__submit {
       width: 100px;
       margin: 10px;

--- a/client/src/Components/Settings/ChangePassword.js
+++ b/client/src/Components/Settings/ChangePassword.js
@@ -28,26 +28,25 @@ class ChangePassword extends Component {
     const { currentPassword, newPassword, confirmNewPassword } = this.state;
 
     // Error handling
-    if ((!currentPassword || !newPassword, !confirmNewPassword)) {
+    if ((!currentPassword || !newPassword, !confirmNewPassword))
       return this.setState({
         changePasswordError: 'Please complete the form'
       });
-    }
-    if (currentPassword.length < 6) {
+
+    if (currentPassword.length < 6)
       return this.setState({
         changePasswordError: 'Current password is invalid'
       });
-    }
-    if (newPassword !== confirmNewPassword) {
+
+    if (newPassword !== confirmNewPassword)
       return this.setState({
         changePasswordError: 'Passwords do not match'
       });
-    }
-    if (newPassword.length < 6) {
+
+    if (newPassword.length < 6)
       return this.setState({
         changePasswordError: 'Password must be at least 6 characters long'
       });
-    }
 
     // If no errors caught, make call to back end
     try {

--- a/client/src/Components/Settings/ChangePassword.js
+++ b/client/src/Components/Settings/ChangePassword.js
@@ -8,15 +8,10 @@ const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 
 class ChangePassword extends Component {
   state = {
-    show: false,
     currentPassword: '',
     newPassword: '',
     confirmNewPassword: '',
     changePasswordError: ''
-  };
-
-  toggleShow = () => {
-    this.setState({ show: !this.state.show });
   };
 
   handleChange = e => {
@@ -32,6 +27,7 @@ class ChangePassword extends Component {
 
     const { currentPassword, newPassword, confirmNewPassword } = this.state;
 
+    // Error handling
     if ((!currentPassword || !newPassword, !confirmNewPassword)) {
       return this.setState({
         changePasswordError: 'Please complete the form'
@@ -53,14 +49,7 @@ class ChangePassword extends Component {
       });
     }
 
-    // Error handling
-    // TODO: Notify user of errors
-    if (!currentPassword) return console.error('Enter your current password!'); // eslint-disable-line
-    if (newPassword !== confirmNewPassword)
-      return console.error('Passwords do not match!'); // eslint-disable-line
-    if (newPassword.length < 6)
-      return console.error('Password needs to be at least 6 characters!'); // eslint-disable-line
-
+    // If no errors caught, make call to back end
     try {
       const url = `${BACKEND_URL}/change_password`;
       const body = {
@@ -80,6 +69,7 @@ class ChangePassword extends Component {
         confirmNewPassword: '',
         show: false
       });
+      // TODO: notify user of success
       console.log('Password updated successfully', response.data);
     } catch (err) {
       // TODO: Notify user of errors
@@ -90,8 +80,8 @@ class ChangePassword extends Component {
   render() {
     return (
       <div className="ChangePassword">
-        <h1 onClick={() => this.toggleShow()}>Change Password...</h1>
-        {this.state.show && (
+        <h1 onClick={() => this.props.handleChangePasswordClick()}>Change Password...</h1>
+        {this.props.showingChangePassword && (
           <form
             onSubmit={this.handleSubmit}
             className="Settings__ChangePassword"

--- a/client/src/Components/Settings/Preferences.js
+++ b/client/src/Components/Settings/Preferences.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 
+import themeColors from '../themeColors.js';
 import './Preferences.css';
 
 class Preferences extends Component {
@@ -18,7 +19,7 @@ class Preferences extends Component {
   };
 
   render() {
-    const theme =
+    const currentTheme =
       this.props.user && this.props.user.preferences
         ? this.props.user.preferences.theme
         : 'dark';
@@ -28,9 +29,14 @@ class Preferences extends Component {
           <h5>Theme</h5>
           <select
             className="Theme"
-            defaultValue={theme}
+            defaultValue={currentTheme}
             name="theme"
             onChange={this.handleChange}
+            style={{
+              backgroundColor: themeColors.background[currentTheme],
+              color: themeColors.fontColor[currentTheme],
+              border: `1px solid ${themeColors.borderColor[currentTheme]}`
+            }}
           >
             <option value="light">light</option>
             <option value="dark">dark</option>

--- a/client/src/Components/Settings/Preferences.less
+++ b/client/src/Components/Settings/Preferences.less
@@ -13,6 +13,12 @@
     h5 {
       margin-right: 10px;
     }
+
+    // select {
+    //   -webkit-appearance: none;
+    //   -moz-appearance: none;
+    //   appearance: none; /* removes default arrow */
+    // }
   }
 
   .Preferences__autoscratch {

--- a/client/src/Components/Settings/Settings.js
+++ b/client/src/Components/Settings/Settings.js
@@ -10,19 +10,29 @@ import themeColors from '../themeColors.js';
 
 class Settings extends Component {
   state = {
-    showingEmail: false,
-    showingPassword: false
+    showingChangeEmail: false,
+    showingChangePassword: false
+  };
+
+  handleChangeEmailClick = () => {
+    this.setState({ showingChangeEmail: !this.state.showingChangeEmail });
+  };
+
+  handleChangePasswordClick = () => {
+    this.setState({ showingChangePassword: !this.state.showingChangePassword });
   };
 
   render() {
     return (
       <AppContextConsumer>
         {({ AppState, handleUpdatePreferences }) => {
-          const currentTheme = AppState.user.preferences ? AppState.user.preferences.theme : 'standard';
+          const currentTheme = AppState.user.preferences
+            ? AppState.user.preferences.theme
+            : 'standard';
           return (
             <div
               className={
-                this.props.showingSettings
+                AppState.showingSettings
                   ? 'Settings Settings-open'
                   : 'Settings Settings-closed'
               }
@@ -36,8 +46,16 @@ class Settings extends Component {
                 user={AppState.user}
                 handleUpdatePreferences={handleUpdatePreferences}
               />
-              <ChangeEmail user={AppState.user} />
-              <ChangePassword user={AppState.user} />
+              <ChangeEmail
+                user={AppState.user}
+                handleChangeEmailClick={this.handleChangeEmailClick}
+                showingChangeEmail={this.state.showingChangeEmail}
+              />
+              <ChangePassword
+                user={AppState.user}
+                handleChangePasswordClick={this.handleChangePasswordClick}
+                showingChangePassword={this.state.showingChangePassword}
+              />
             </div>
           );
         }}

--- a/client/src/Components/Settings/Settings.js
+++ b/client/src/Components/Settings/Settings.js
@@ -54,7 +54,8 @@ class Settings extends Component {
               }
               style={{
                 backgroundColor: themeColors.background[currentTheme],
-                color: themeColors.color[currentTheme]
+                color: themeColors.color[currentTheme],
+                border: `1px solid ${themeColors.color[currentTheme]}`
               }}
             >
               <div className="Settings__Header">Settings</div>

--- a/client/src/Components/Settings/Settings.js
+++ b/client/src/Components/Settings/Settings.js
@@ -15,11 +15,27 @@ class Settings extends Component {
   };
 
   handleChangeEmailClick = () => {
-    this.setState({ showingChangeEmail: !this.state.showingChangeEmail });
+    if (this.state.showingChangePassword)
+      this.setState({
+        showingChangePassword: false,
+        showingChangeEmail: !this.state.showingChangeEmail
+      });
+    else
+      this.setState({
+        showingChangeEmail: !this.state.showingChangeEmail
+      });
   };
 
   handleChangePasswordClick = () => {
-    this.setState({ showingChangePassword: !this.state.showingChangePassword });
+    if (this.state.showingChangeEmail)
+      this.setState({
+        showingChangeEmail: false,
+        showingChangePassword: !this.state.showingChangePassword
+      });
+    else
+      this.setState({
+        showingChangePassword: !this.state.showingChangePassword
+      });
   };
 
   render() {

--- a/client/src/Components/Settings/Settings.js
+++ b/client/src/Components/Settings/Settings.js
@@ -54,8 +54,8 @@ class Settings extends Component {
               }
               style={{
                 backgroundColor: themeColors.background[currentTheme],
-                color: themeColors.color[currentTheme],
-                border: `1px solid ${themeColors.color[currentTheme]}`
+                color: themeColors.fontColor[currentTheme],
+                border: `1px solid ${themeColors.borderColor[currentTheme]}`
               }}
             >
               <div className="Settings__Header">Settings</div>

--- a/client/src/Components/themeColors.js
+++ b/client/src/Components/themeColors.js
@@ -4,14 +4,28 @@ const themeColors = {
     dark: '#444',
     watercolor: '#DCC',
     toner: '#222',
-    standard: 'white'
+    standard: '#FFF'
   },
   color: {
-    light: 'gray',
-    dark: 'white',
-    watercolor: 'black',
-    toner: 'white',
-    standard: 'gray'
+    light: '#808080',
+    dark: '#AAA',
+    watercolor: '#000',
+    toner: '#808080',
+    standard: '#808080'
+  },
+  fontColor: {
+    light: '#808080',
+    dark: '#AAA',
+    watercolor: '#000',
+    toner: '#808080',
+    standard: '#808080'
+  },
+  borderColor: {
+    light: '#808080',
+    dark: '#888',
+    watercolor: '#000',
+    toner: '#808080',
+    standard: '#808080'
   }
 };
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -149,7 +149,7 @@ input {
   font-size: 1em;
   color: inherit;
   padding: 10px;
-  border: 1px solid rgba(200, 200, 200, 0.6);
+  border: 1px solid #AAA;
   background-color: inherit;
 }
 select,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -148,7 +148,7 @@ input {
   font-family: Roboto, sans-serif;
   font-size: 1em;
   color: inherit;
-  padding: 8px;
+  padding: 10px;
   border: 1px solid rgba(200, 200, 200, 0.6);
   background-color: inherit;
 }

--- a/client/src/index.less
+++ b/client/src/index.less
@@ -58,7 +58,7 @@ button, input {
   font-size: 1em;
   color: inherit;
   padding: 10px;
-  border: 1px solid rgba(200, 200, 200, 0.6);
+  border: 1px solid #AAA;
   background-color: inherit;
 }
 

--- a/client/src/index.less
+++ b/client/src/index.less
@@ -57,7 +57,7 @@ button, input {
   font-family: Roboto, sans-serif;
   font-size: 1em;
   color: inherit;
-  padding: 8px;
+  padding: 10px;
   border: 1px solid rgba(200, 200, 200, 0.6);
   background-color: inherit;
 }


### PR DESCRIPTION
# Description

- Only allow either `ChangeEmail` or `ChangePassword` contents to be open at once. If one is open when clicking the other, the already open element will be closed and the clicked on element will open.
- Move handlers and state properties for `ChangeEmail`/`ChangePassword` to `AppContext`.
- Add styling to country search input field
- Code cleanup
- Fix for #120 
- Temporary fix for #125 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested manually in browser
- All existing tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
