### PR TITLE
Implement autoscratch setting

### DIFF
--- a/client/src/Components/CountryBorder/CountryBorder.js
+++ b/client/src/Components/CountryBorder/CountryBorder.js
@@ -13,13 +13,6 @@ import travellingImg from '../../travelling.jpg';
 const canvasWidth = 300;
 const canvasHeight = 150;
 
-const scratchcardSettings = {
-  width: canvasWidth,
-  height: canvasHeight,
-  image: travellingImg,
-  finishPercent: 95
-};
-
 const draw = (context, canvasWidth, canvasHeight, bounds, geometry, color) => {
   context.fillStyle = color || '#333';
 
@@ -149,6 +142,13 @@ export default class CountryBorder extends Component {
   };
 
   render() {
+    const scratchcardSettings = {
+      width: canvasWidth,
+      height: canvasHeight,
+      image: travellingImg,
+      finishPercent: this.props.preferences.autoscratch ? 1 : 95
+    };
+
     return (
       <div className="CountryBorder">
         {this.props.scratched ? (
@@ -200,5 +200,6 @@ CountryBorder.propTypes = {
   handleSliderMove: PropTypes.func,
   handleScratched: PropTypes.func,
   currentCountryStatus: PropTypes.any,
-  scratched: PropTypes.bool
+  scratched: PropTypes.bool,
+  preferences: PropTypes.object
 };

--- a/client/src/Components/CountryBorder/CountryBorder.js
+++ b/client/src/Components/CountryBorder/CountryBorder.js
@@ -146,8 +146,13 @@ export default class CountryBorder extends Component {
       width: canvasWidth,
       height: canvasHeight,
       image: travellingImg,
-      finishPercent: this.props.preferences.autoscratch ? 1 : 95
+      finishPercent: 90
     };
+
+    if (this.props.preferences)
+      scratchcardSettings.finishPercent = this.props.preferences.autoscratch
+        ? 1
+        : 90;
 
     return (
       <div className="CountryBorder">

--- a/client/src/Components/CountryPanel/CountryPanel.js
+++ b/client/src/Components/CountryPanel/CountryPanel.js
@@ -54,6 +54,7 @@ const CountryPanel = () => {
                 handleScratched={value.handleScratched}
                 currentCountryStatus={value.AppState.currentCountryStatus}
                 scratched={value.AppState.currentCountry.scratched}
+                preferences={value.AppState.user.preferences}
               />
               {value.AppState.currentCountry.scratched ? (
                 <Note

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -23,7 +23,7 @@ const Nav = props => {
             <h1 className="Nav__title">MapScratcher</h1>
 
             <div className="Nav__Center">
-              {AppState.user.facebook ? (
+              {AppState.user.facebook && AppState.user.facebook.id ? (
                 <select
                   name="My Travels"
                   id=""

--- a/client/src/Components/Settings/Preferences.js
+++ b/client/src/Components/Settings/Preferences.js
@@ -6,7 +6,8 @@ import './Preferences.css';
 
 class Preferences extends Component {
   state = {
-    autoscratch: false
+    autoscratch: false,
+    theme: 'standard'
   };
 
   handleChange = event => {
@@ -18,6 +19,11 @@ class Preferences extends Component {
       [name]: value
     });
   };
+
+  componentDidMount() {
+    if (this.props.user && this.props.user.preferences)
+      this.setState({ theme: this.props.user.preferences.theme });
+  }
 
   render() {
     const currentTheme =

--- a/client/src/Components/Settings/Preferences.js
+++ b/client/src/Components/Settings/Preferences.js
@@ -22,7 +22,10 @@ class Preferences extends Component {
 
   componentDidMount() {
     if (this.props.user && this.props.user.preferences)
-      this.setState({ theme: this.props.user.preferences.theme });
+      this.setState({
+        theme: this.props.user.preferences.theme,
+        autoscratch: this.props.user.preferences.autoscratch
+      });
   }
 
   render() {
@@ -74,6 +77,6 @@ class Preferences extends Component {
 Preferences.propTypes = {
   user: PropTypes.object,
   handleUpdatePreferences: PropTypes.any
-}
+};
 
 export default Preferences;


### PR DESCRIPTION
# Description

- When user has autoscratch enabled, the scratchcard threshold is set to '1' so that a single click will reveal the country border
- Fix an issue where the friends dropdown for was being rendering for non-FB users upon updating preferences

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested manually
- Existing tests continue to pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
